### PR TITLE
Fix use of BROWSER instead of DRIVER in rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,11 +10,11 @@ end
 desc 'Run using Firefox browser (add PAUSE=1 for 1 sec pause between pages)'
 task :firefox do
   pause = ENV['PAUSE'].to_i ||= 0
-  sh %( BROWSER=firefox PAUSE=#{pause} bundle exec cucumber )
+  sh %( DRIVER=firefox PAUSE=#{pause} bundle exec cucumber )
 end
 
 desc 'Run using Chrome browser (add PAUSE=1 to for sec pause between pages)'
 task :chrome do
   pause = ENV['PAUSE'].to_i ||= 0
-  sh %( BROWSER=chrome PAUSE=#{pause} bundle exec cucumber )
+  sh %( DRIVER=chrome PAUSE=#{pause} bundle exec cucumber )
 end


### PR DESCRIPTION
Recently we switched using BROWSER for the name of an environment variable (see https://github.com/EnvironmentAgency/quke/commit/20c12859ccb2fdd35fd746648dba53c53ccc3878) to DRIVER in order to resolve a problem preventing [Launchy](https://github.com/copiousfreetime/launchy) from working.

However it looks like we failed to update the use of the environment variable in `Rakefile` so this change rectifies that oversight.
