### PR TITLE
Make use of hooks clearer in project

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -71,9 +71,3 @@ driver = case (ENV['DRIVER'] || '').downcase.strip
 
 Capybara.default_driver = driver
 Capybara.javascript_driver = driver
-
-# We use cucumber's AfterStep hook to insert our pause between pages if
-# one was set
-AfterStep do
-  sleep((ENV['PAUSE'] || 0).to_i)
-end

--- a/features/support/hooks/quke/after_step.rb
+++ b/features/support/hooks/quke/after_step.rb
@@ -1,0 +1,5 @@
+# We use cucumber's AfterStep hook to insert our pause between pages if
+# one was set
+AfterStep do
+  sleep((ENV['PAUSE'] || 0).to_i)
+end


### PR DESCRIPTION
Cucumber has the concept of hooks. These are a way of running code [before, after, or around a feature](https://github.com/cucumber/cucumber/wiki/Hooks), or even before and after an individual step. We use an `after_step` hook to enable the pause functionality to work.

This change makes the use of hooks clearer in general by creating a folder called `hooks`, and moving the `after_step` hook for pausing between steps to a separate file within the folder.
