### PR TITLE
Save custom quke args to global env vars

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,12 @@
+AllCops:
+  # Cop names are not displayed in offense messages by default. We find it useful to include this information so we can
+  # use it to investigate what the fix may be.
+  DisplayCopNames: true
+  # Style guide URLs are not displayed in offense messages by default. Again we find it useful to go straight to the
+  # documentation for a rule when investigating what the fix may be.
+  DisplayStyleGuide: true
+
+# Disable this rubocop style because we want to make the arguments passed into quke available to anywhere when the code
+# is executed rubocop:disable Style/GlobalVars
+Style/GlobalVars:
+  Enabled: false

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -60,14 +60,21 @@ end
 # The choice of which browser to use for the tests is dependent on what the
 # environment variable DRIVER is set to. If not set we default to using
 # poltergeist
-driver = case (ENV['DRIVER'] || '').downcase.strip
-         when 'firefox'
-           :firefox
-         when 'chrome'
-           :chrome
-         else
-           :poltergeist
-         end
+# We capture the value as a global env var so if necessary choice of browser
+# can be referenced elsewhere, for example in any debug output.
+$driver = case (ENV['DRIVER'] || '').downcase.strip
+          when 'firefox'
+            :firefox
+          when 'chrome'
+            :chrome
+          else
+            :poltergeist
+          end
 
-Capybara.default_driver = driver
-Capybara.javascript_driver = driver
+Capybara.default_driver = $driver
+Capybara.javascript_driver = $driver
+
+# We capture the value as a global env var so if necessary length of time
+# between page interactions can be referenced elsewhere, for example in any
+# debug output.
+$pause = (ENV['PAUSE'] || 0).to_i

--- a/features/support/hooks/quke/after_step.rb
+++ b/features/support/hooks/quke/after_step.rb
@@ -1,5 +1,5 @@
 # We use cucumber's AfterStep hook to insert our pause between pages if
 # one was set
 AfterStep do
-  sleep((ENV['PAUSE'] || 0).to_i)
+  sleep($pause)
 end


### PR DESCRIPTION
This change saves the values of DRIVER and PAUSE (qukes custom arguments) to global variables so they can be accessed from anywhere else in the code base. The expected use of these variables is in things like extra functionality around fail scenarios, but at this point its just about making them accessible.
