### PR TITLE
Add function to open page on fail

### DIFF
--- a/features/step_definitions/quke/demo_steps.rb
+++ b/features/step_definitions/quke/demo_steps.rb
@@ -20,7 +20,7 @@ Then(/^both are (\d+) cm long$/) do |length|
 end
 
 Given(/^I am on the home page$/) do
-  puts visit 'https://en.wikipedia.org/wiki/Main_Page'
+  visit 'https://en.wikipedia.org/wiki/Main_Page'
 end
 
 When(/^I fill in "([^"]*)" with "([^"]*)"$/) do |element, text|

--- a/features/support/hooks/quke/after.rb
+++ b/features/support/hooks/quke/after.rb
@@ -8,6 +8,17 @@ After('~@nonweb') do |scenario|
       return
     end
 
+    # Experience has shown that should a major element of your service go
+    # down all your tests will start failing which means you can be swamped
+    # with output from `save_and_open_page`. This keeps a global count of the
+    # number of fails, and if it hits 5 it will cause cucumber to close.
+    $fail_count ||= 0
+    $fail_count = $fail_count + 1
+    if $fail_count >= 5
+      Cucumber.wants_to_quit = true
+      return
+    end
+
     # If we're not using poltergiest and the scenario has failed, we want
     # to save a copy of the page and open it automatically using Launchy.
     # We wrap this in a begin/rescue in case of any issues in which case

--- a/features/support/hooks/quke/after.rb
+++ b/features/support/hooks/quke/after.rb
@@ -1,0 +1,27 @@
+After('~@nonweb') do |scenario|
+  if scenario.failed?
+    # Tell Cucumber to quit after first failing scenario when poltergeist is
+    # used. The expectation is that you are using poltergeist as part of your
+    # CI and therefore a fast response is better than a detailed response
+    if $driver == :poltergeist
+      Cucumber.wants_to_quit = true
+      return
+    end
+
+    # If we're not using poltergiest and the scenario has failed, we want
+    # to save a copy of the page and open it automatically using Launchy.
+    # We wrap this in a begin/rescue in case of any issues in which case
+    # it defaults to outputting the source to STDOUT.
+    begin
+      # rubocop:disable Lint/Debugger
+      save_and_open_page
+      # rubocop:enable Lint/Debugger
+    rescue StandardError
+      # handle e
+      puts "FAILED: #{scenario.name}"
+      puts "FAILED: URL of the page with the test failure #{page.current_path}"
+      puts ''
+      puts page.html
+    end
+  end
+end


### PR DESCRIPTION
When testing using the selenium driver (either the Chrome or Firefox browser) in the event of a fail you are likely to want to see the page where the failure occurs to help with resolving why it failed.

This change covers
- Adding an after hook to call `save_and_open_page` when a scenario fails as long as the driver is not poltergeist
- In the same hook if the driver is poltergeist don't show a page, but close cucumber. Assumption is based on poltergiest is being used in a CI environment where fast feedback is preferred to detailed feedback
