### PR TITLE
Make url endpoint to be tested configurable

### DIFF
--- a/features/step_definitions/quke/demo_steps.rb
+++ b/features/step_definitions/quke/demo_steps.rb
@@ -21,6 +21,7 @@ end
 
 Given(/^I am on the home page$/) do
   visit 'https://en.wikipedia.org/wiki/Main_Page'
+  expect(page).to have_content('Welcome to Wikipedia')
 end
 
 When(/^I fill in "([^"]*)" with "([^"]*)"$/) do |element, text|
@@ -35,6 +36,7 @@ end
 Given(/^I am on the wikipedia home page$/) do
   @quke_demo_page = QukeDemoPage.new
   @quke_demo_page.load
+  expect(page).to have_content('Welcome to Wikipedia')
 end
 
 When(/^I search for "([^"]*)"$/) do |text|

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -23,6 +23,15 @@ require 'site_prism'
 # selectors in your step definitions to use the XPath syntax.
 # Capybara.default_selector = :xpath
 
+# Normally Capybara expects to be testing an in-process Rack application, but
+# we're using it to talk to a remote host. Users of quke can set what this will
+# be by simply setting the environment variable APP_HOST. An example would be
+# APP_HOST='https://en.wikipedia.org/wiki'. You can then use it directly using
+# Capybara `visit('/Main_Page')` or `visit('/')`. In your page_objects
+# `set_url '/Main_Page'`
+$app_host = (ENV['APP_HOST'] || '')
+Capybara.app_host = $app_host
+
 # Here we are registering the poltergeist driver with capybara. There are a
 # number of options for how to configure poltergeist, and we can even pass
 # on options to phantomjs to configure how it runs

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -83,6 +83,11 @@ $driver = case (ENV['DRIVER'] || '').downcase.strip
 Capybara.default_driver = $driver
 Capybara.javascript_driver = $driver
 
+# By default Capybara will try to boot a rack application automatically. This
+# switches off Capybara's rack server as we are running against a remote
+# application.
+Capybara.run_server = false
+
 # We capture the value as a global env var so if necessary length of time
 # between page interactions can be referenced elsewhere, for example in any
 # debug output.


### PR DESCRIPTION
https://github.com/EnvironmentAgency/quke/issues/8

Currently Quke and its examples have been built on the premise that the website undertest would be at a fixed address set within the test code. However initial feedback has shown this may not always be the case, for example QA may want to test against its own QA environment, then pre-prod, and then production upon release of the service.

This change will add the ability for the user to configure the url using an environment variable.

(Resolves issue #8)
