### PR TITLE
Enable Capybara implicit waits in Quke

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -92,3 +92,11 @@ Capybara.run_server = false
 # between page interactions can be referenced elsewhere, for example in any
 # debug output.
 $pause = (ENV['PAUSE'] || 0).to_i
+
+# By default, SitePrism element and section methods do not utilize Capybara's
+# implicit wait methodology and will return immediately if the element or
+# section requested is not found on the page. Adding the following code
+# enables Capybara's implicit wait methodology to pass through
+SitePrism.configure do |config|
+  config.use_implicit_waits = true
+end


### PR DESCRIPTION
https://github.com/natritmeyer/site_prism#using-capybara-implicit-waits

By default, SitePrism element and section methods do not utilize Capybara's implicit wait methodology and will return immediately if the element or section requested is not found on the page.

This means users may have to write their steps as

``` ruby
# wait_until methods always wait for the element to be present on the page:
@search_page.wait_for_search_results

# Element and section methods do not:
@search_page.search_results
```

With implicit waits enabled they just have to write

``` ruby
# With implicit waits enabled, use of wait_until methods is no longer required. This method will
# wait for the element to be found on the page until the Capybara default timeout is reached.
@search_page.search_results
```

We think this leads to cleaner and clearer code hence this change enables Capybara's implicit wait methodology.
