### PR TITLE
Add example of interacting with radio-buttons

### DIFF
--- a/features/quke/radio_buttons.feature
+++ b/features/quke/radio_buttons.feature
@@ -1,0 +1,22 @@
+Feature: Radio buttons
+  To demonstrate how you can use Quke
+  As a user of Quke
+  I want to see how to interact with radio buttons and check the results
+
+  Scenario: Confirming number of radio buttons (page objects)
+    Given I am on the radio button page
+     Then I should see 5 options
+
+  Scenario: Confirming number of radio buttons  (capybara)
+    Given I'm at the radio button page
+     Then I should get 5 options
+
+  Scenario: Confirming I can select a radio button (page objects)
+    Given I am on the radio button page
+      And I select an option
+     Then I should see a confirmation of my selection
+
+  Scenario: Confirming I can select a radio button (capybara)
+    Given I'm at the radio button page
+      And I select one of the options
+     Then I should my selection confirmed

--- a/features/step_definitions/quke/radio_button_steps.rb
+++ b/features/step_definitions/quke/radio_button_steps.rb
@@ -1,0 +1,50 @@
+# The following steps use the page objects to drive the browser
+Given(/^I am on the radio button page$/) do
+  @app = QukeApp.new
+  @app.radio_button_page.load
+  expect(@app.radio_button_page.title.text).to eq('Radio button')
+end
+
+Then(/^I should see (\d+) options$/) do |num_of_results|
+  expect(@app.radio_button_page.options.size).to eq(Integer(num_of_results))
+end
+
+Given(/^I select an option$/) do
+  # This demonstrates reuse of a step. We want to ensure we can see options
+  # before trying to select one, but rather than repeat the same expectation
+  # we instead reuse the step that does this.
+  step 'I should see 5 options'
+
+  # rubocop: disable LineLength
+  @app.radio_button_page.options.find { |btn| btn.value == 'WasteExemptionsShared::OrganisationType::Partnership' }.click
+  # rubocop: enable LineLength
+
+  @app.radio_button_page.confirm_button.click
+end
+
+Then(/^I should see a confirmation of my selection$/) do
+  expect(@app.radio_button_page.result.text).to end_with('Partnership')
+end
+
+# The following steps use capybara directly to drive the browser
+Given(/^I'm at the radio button page$/) do
+  visit 'http://localhost:4567/radiobutton'
+  expect(page).to have_content('Radio button')
+end
+
+Then(/^I should get (\d+) options$/) do |num_of_results|
+  expect(page.all('input[type=radio]').size).to eq(Integer(num_of_results))
+end
+
+Given(/^I select one of the options$/) do
+  # This demonstrates reuse of a step. We want to ensure we can see options
+  # before trying to select one, but rather than repeat the same expectation
+  # we instead reuse the step that does this.
+  step 'I should get 5 options'
+  choose('organisation_partnership')
+  click_button('commit')
+end
+
+Then(/^I should my selection confirmed$/) do
+  expect(find('span[id=result]').text).to end_with('Partnership')
+end

--- a/features/support/page_objects/quke/quke_app.rb
+++ b/features/support/page_objects/quke/quke_app.rb
@@ -12,4 +12,8 @@ class QukeApp
   def search_page
     @last_page = QukeSearchPage.new
   end
+
+  def radio_button_page
+    @last_page = QukeRadioButtonPage.new
+  end
 end

--- a/features/support/page_objects/quke/quke_radio_button_page.rb
+++ b/features/support/page_objects/quke/quke_radio_button_page.rb
@@ -1,0 +1,10 @@
+# Radio button page
+class QukeRadioButtonPage < SitePrism::Page
+  set_url 'http://localhost:4567/radiobutton'
+
+  element :title, 'h1'
+  element :confirm_button, "input[name='commit']"
+  element :result, "span[id='result']"
+
+  elements :options, "input[name='enrollment[organisation_attributes][type]']"
+end

--- a/quke_demo_app/app.rb
+++ b/quke_demo_app/app.rb
@@ -37,6 +37,8 @@ get '/search' do
 end
 
 post '/search' do
+  @title = 'Search'
+
   @query = params['search_input']
 
   # rubocop:disable Metrics/LineLength
@@ -47,4 +49,17 @@ post '/search' do
   # rubocop:enable Metrics/LineLength
 
   erb :search
+end
+
+get '/radiobutton' do
+  @title = 'Radio button'
+  erb :radio_button
+end
+
+post '/radiobutton' do
+  @title = 'Radio button'
+  @selection = params['enrollment']['organisation_attributes']['type']
+  @result = @selection.match(/OrganisationType::([^"]*)/)[1]
+
+  erb :radio_button
 end

--- a/quke_demo_app/views/index.erb
+++ b/quke_demo_app/views/index.erb
@@ -1,11 +1,12 @@
 <!-- Main jumbotron for a primary marketing message or call to action -->
 <div class="jumbotron">
   <h1><%= @title %> <img src="/assets/images/quke.png" width="65px" align="middle" /></h1>
-  <p class="lead">Use this document as a way to quickly start any new project.<br /> All you get is this text and a mostly barebones HTML document.</p>
+  <p class="lead">This demo app is what the example features run against.<br /> Use it along with the features to explore how to interact with your web sites using Quke.</p>
 </div>
 
 <ul>
   <li><a href="/search">Search</a></li>
+  <li><a href="/radiobutton">Radio buttons</a></li>
 </ul>
 
 <%= erb '_partial_example'.to_sym %>

--- a/quke_demo_app/views/radio_button.erb
+++ b/quke_demo_app/views/radio_button.erb
@@ -1,0 +1,43 @@
+      <header>
+        <h1><%= @title %></h1>
+      </header>
+
+      <form id="radio_button_example" action="/radiobutton" accept-charset="UTF-8" method="post">
+        <fieldset>
+
+          <div id="form_group_organisation_type" role="group" aria-labelledby="groupLabel" class="form">
+            <label class="radio" for="organisation_limited_company">
+              <input id="organisation_limited_company" type="radio" value="WasteExemptionsShared::OrganisationType::LimitedCompany" name="enrollment[organisation_attributes][type]" />
+              Limited company
+            </label>
+            <label class="radio" for="organisation_limited_liability_partnership">
+              <input id="organisation_limited_liability_partnership" type="radio" value="WasteExemptionsShared::OrganisationType::LimitedLiabilityPartnership" name="enrollment[organisation_attributes][type]" />
+              Limited liability partnership
+            </label>
+            <label class="radio" for="organisation_partnership">
+              <input id="organisation_partnership" type="radio" value="WasteExemptionsShared::OrganisationType::Partnership" name="enrollment[organisation_attributes][type]" />
+              Partnership
+            </label>
+            <label class="radio" for="organisation_other">
+              <input id="organisation_other" type="radio" value="WasteExemptionsShared::OrganisationType::Other" name="enrollment[organisation_attributes][type]" />
+              Other (trust, club or public body)
+            </label>
+            <label class="radio" for="organisation_not_known">
+              <input id="organisation_not_known" type="radio" value="WasteExemptionsShared::OrganisationType::NotKnown" name="enrollment[organisation_attributes][type]" />
+              I don’t know
+            </label>
+          </div>
+        </fieldset>
+
+        <div class="actions">
+          <input type="submit" id="commit" name="commit" value="Continue" class="button"/>
+        </div>
+      </form>
+      <% if @result %>
+      <div id="results">
+        <h2>Results</h2>
+        <div id="selected-option" class="result">
+          <p class="result-desc"><span id="result">You selected <strong><%= @result %></strong></span></p>
+        </div>
+      </div>
+      <% end %>


### PR DESCRIPTION
This change adds an example of how to use either SitePrism and the page object method or Capybara directly to interact with a page that features radio buttons.
