### PR TITLE
Stop saving to root when save_and_open_page used

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,3 +27,8 @@ task :run do
     sh %( bundle exec ruby quke_demo_app/app.rb )
   end
 end
+
+desc 'Delete all Capybara saved pages in the tmp directory'
+task :clean do
+  File.delete(*Dir.glob('tmp/capybara-*.html'))
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -88,6 +88,13 @@ Capybara.javascript_driver = $driver
 # application.
 Capybara.run_server = false
 
+# When calling save_and_open_page the current html page is saved to file for
+# debug purposes. This can be done directly within a step or happens
+# automatically in the event of an error when using the selenium driver.
+# Not setting this leads to Capybara saving the file to the root of the project
+# which can get in the way when trying to work with Quke in your projects.
+Capybara.save_and_open_page_path = 'tmp/'
+
 # We capture the value as a global env var so if necessary length of time
 # between page interactions can be referenced elsewhere, for example in any
 # debug output.


### PR DESCRIPTION
Currently if `save_and_open_page` is called or a page errors when using the selenium-webdriver the current page is saved by Capybara and launched by Launchy automatically.

The problem is the files are being created in the root of the project. The `.gitignore` file is already set to ignore them, but when working on a project they start getting in the way of trying to navigate the source files.

This change sets the Capybara config to save them to a `tmp/` folder instead, and adds a new rake task to allow users to quickly delete them.
