### PR TITLE
Integrate with Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: ruby
+rvm:
+  - 2.3.1
+
+# Travis CI clones repositories to a depth of 50 commits, which is only really
+# useful if you are performing git operations.
+# https://docs.travis-ci.com/user/customizing-the-build/#Git-Clone-Depth
+git:
+  depth: 3
+
+# enable Bundler caching
+# https://docs.travis-ci.com/user/languages/ruby#Caching-Bundler
+cache: bundler
+
+# Exclude non-essential gem dependencies
+# https://docs.travis-ci.com/user/languages/ruby#Speeding-up-your-build-by-excluding-non-essential-dependencies
+bundler_args: --without development
+
+script:
+  - bundle exec thin -c quke_demo_app/ -p 4567 -d --tag quke start
+  - bundle exec cucumber -p quke

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Quke
+# Quke <img src="/quke_demo_app/public/assets/images/quke.png" alt="Git flow" style="width: 50px;"/>
+
+[![Build Status](https://travis-ci.org/EnvironmentAgency/quke.svg?branch=master)](https://travis-ci.org/EnvironmentAgency/quke)
 
 A template repo for building [Cucumber](https://cucumber.io/) feature tests that can be run against a web site. Unlike normal setups the feature tests do not need to be included with the source code for the site to be tested. Instead this template project includes the ability to run them standalone.
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -93,7 +93,7 @@ Capybara.run_server = false
 # automatically in the event of an error when using the selenium driver.
 # Not setting this leads to Capybara saving the file to the root of the project
 # which can get in the way when trying to work with Quke in your projects.
-Capybara.save_and_open_page_path = 'tmp/'
+Capybara.save_path = 'tmp/'
 
 # We capture the value as a global env var so if necessary length of time
 # between page interactions can be referenced elsewhere, for example in any

--- a/quke_demo_app/app.rb
+++ b/quke_demo_app/app.rb
@@ -13,6 +13,8 @@ configure do
   # We don't want the browser caching the assets so we specify this
   set :static_cache_control, [:public, max_age: 0]
 
+  # It's not critical for this app, but best practise is to secure your session
+  # with a secret key, and this also stops Sinatra complaining!
   set :session_secret, SECRET ||= 'super secret'.freeze
 end
 

--- a/quke_demo_app/config.ru
+++ b/quke_demo_app/config.ru
@@ -1,0 +1,9 @@
+# The config.ru file allows us to use any Rack handler, which in our case is
+# [Thin](https://github.com/macournoyer/thin) to start the app, rather than
+# relying on Sinatra magic.
+# This now means we can start the app using thin directly with direct access
+# to all the args you can normally pass into it. We mainly needed this to allow
+# us to start the app using thin on Travis-CI, so we could then run the tests
+# against it.
+require './app'
+run Sinatra::Application


### PR DESCRIPTION
Now we have removed the dependency on an external site for our examples features, we can integrate Quke with a Ci service.

This change sets up the project to work with Travis CI so future changes will automatically be tested.
