### PR TITLE
Add explanation to demo pages on what tests show

### DIFF
--- a/quke_demo_app/views/index.erb
+++ b/quke_demo_app/views/index.erb
@@ -1,12 +1,14 @@
-<!-- Main jumbotron for a primary marketing message or call to action -->
-<div class="jumbotron">
-  <h1><%= @title %> <img src="/assets/images/quke.png" width="65px" align="middle" /></h1>
-  <p class="lead">This demo app is what the example features run against.<br /> Use it along with the features to explore how to interact with your web sites using Quke.</p>
-</div>
+      <!-- Main jumbotron for a primary marketing message or call to action -->
+      <header>
+        <div class="jumbotron">
+          <h1><%= @title %> <img src="/assets/images/quke.png" width="65px" align="middle" /></h1>
+          <p class="lead">This demo app is what the example features run against.<br /> Use it along with the features to explore how to interact with your web sites using Quke.</p>
+        </div>
+      </header>
 
-<ul>
-  <li><a href="/search">Search</a></li>
-  <li><a href="/radiobutton">Radio buttons</a></li>
-</ul>
+      <ul>
+        <li><a href="/search">Search</a></li>
+        <li><a href="/radiobutton">Radio buttons</a></li>
+      </ul>
 
-<%= erb '_partial_example'.to_sym %>
+      <%= erb '_partial_example'.to_sym %>

--- a/quke_demo_app/views/radio_button.erb
+++ b/quke_demo_app/views/radio_button.erb
@@ -1,6 +1,18 @@
-      <header>
+      <!-- Main jumbotron for a primary marketing message or call to action -->
+      <div class="jumbotron">
         <h1><%= @title %></h1>
-      </header>
+        <p class="lead">Tests for this page are all about working with collections of elements like radio buttons.
+          The steps behind <code>radio_button.feature</code> show getting a collection of linked elements, checking
+          you have the right number, and for something like a radio button how to select a specific one.</p>
+        <p class="lead">Though the examples are for radio buttons, the same selecting and checking logic can be
+          used with any elements e.g. <code>&lt;div&gt;</code>, <code>&lt;a&gt;</code>, <code>&lt;tr&gt;</code>.
+          It just comes down to the CSS selector you use. See the following for details</p>
+        <ul>
+          <li><code>features/quke/radio_button.feature</code></li>
+          <li><code>features/step_definitions/quke/radio_button_steps.rb</code></li>
+          <li><code>quke_demo_app/views/radio_button.erb</code></li>
+        </ul>
+      </div>
 
       <form id="radio_button_example" action="/radiobutton" accept-charset="UTF-8" method="post">
         <fieldset>

--- a/quke_demo_app/views/search.erb
+++ b/quke_demo_app/views/search.erb
@@ -1,6 +1,15 @@
-      <header>
+      <!-- Main jumbotron for a primary marketing message or call to action -->
+      <div class="jumbotron">
         <h1><%= @title %></h1>
-      </header>
+        <p class="lead">The steps for <code>search.feature</code> demonstrate how to fill in a form, submit it and then
+          test the response is what you expected. In this case that's confirming you got the right number of results and that they
+          contained the correct data. See the following for details</p>
+        <ul>
+          <li><code>features/quke/search.feature</code></li>
+          <li><code>features/step_definitions/quke/search_steps.rb</code></li>
+          <li><code>quke_demo_app/views/search.erb</code></li>
+        </ul>
+      </div>
 
       <form class="edit_grid_reference" id="edit_grid_reference" action="/search" accept-charset="UTF-8" method="post">
         <fieldset>


### PR DESCRIPTION
This change updates each of the pages in the Quke demo app with an explanation that details what the tests related to that page are trying to demonstrate, and what are the key files to refer to.
