### PR TITLE
Add examples of CSS selectors to project

### DIFF
--- a/features/quke/css_selectors.feature
+++ b/features/quke/css_selectors.feature
@@ -1,0 +1,66 @@
+Feature: Radio buttons
+  When writing my own steps and page objects
+  As a user of Quke
+  I would like a reference to examples of css selectors
+
+  # Examples are attributed to http://trevordavis.net/blog/css-attribute-selectors-explained/
+
+  # [attr]
+  # Whenever the attribute is set. Ex: input[type]
+  Scenario: Selecting all elements with a specific attribute using page objects
+    Given I am on the css selectors page
+     Then I should be able to select all href links
+
+  Scenario: Selecting all elements with a specific attribute using capybara
+    Given I'm at the css selectors page
+     Then I can select all href links
+
+  # [attr="val"]
+  # Whenever the attribute equals the specific value. Ex: input[type="radio"]
+  Scenario: Selecting all elements with an attribute of type="radio" using page objects
+    Given I am on the css selectors page
+     Then I should be able to select all the radio buttons
+
+  Scenario: Selecting all elements with an attribute of type="radio" using capybara
+    Given I'm at the css selectors page
+     Then I can select all the radio buttons
+
+  # [attr~="val"]
+  # Whenever the attribute equals one of the space separated list of values. Ex: input[type~="radio checkbox"]
+  Scenario: Selecting all elements with an attribute of type "radio" or "checkbox" using page objects
+    Given I am on the css selectors page
+     Then I should be able to select all the radio buttons and checkboxes
+
+  Scenario: Selecting all elements with an attribute of type "radio" or "checkobox" using capybara
+    Given I'm at the css selectors page
+     Then I can select all the radio buttons and checkboxes
+
+  # [attr*="val"]
+  # Whenever the attribute contains the value. Ex: a[href*=".com"]
+  Scenario: Selecting a link element that contains the value 'About' using page objects
+    Given I am on the css selectors page
+     Then I should be able to select the about link element
+
+  Scenario: Selecting a link element that contains the value 'About' using capybara
+    Given I'm at the css selectors page
+     Then I can select the about link
+
+  # [attr^="val"]
+  # Whenever the attribute starts with the value. Ex: a[href^="http"]
+  Scenario: Selecting a link element that starts with '/con' using page objects
+    Given I am on the css selectors page
+     Then I should be able to select the contact link element
+
+  Scenario: Selecting a link element that starts with '/con' using capybara
+    Given I'm at the css selectors page
+     Then I can select the contact link
+
+  # [attr$="val"]
+  # Whenever the attribute ends with the value. Ex: a[href$=".pdf"]
+  Scenario: Selecting a button element that ends with 'mmit' using page objects
+    Given I am on the css selectors page
+     Then I should be able to select the continue button element
+
+  Scenario: Selecting a button element that ends with 'mmit' using capybara
+    Given I'm at the css selectors page
+     Then I can select the continue button element

--- a/features/step_definitions/quke/css_selector_steps.rb
+++ b/features/step_definitions/quke/css_selector_steps.rb
@@ -1,0 +1,66 @@
+# The following steps use the page objects to drive the browser
+# -------------------------------------------------------------
+
+Given(/^I am on the css selectors page$/) do
+  @app = QukeApp.new
+  @app.css_selectors_page.load
+  expect(@app.css_selectors_page.title.text).to eq('CSS selector')
+end
+
+Then(/^I should be able to select all href links$/) do
+  expect(@app.css_selectors_page.links).not_to be_empty
+end
+
+Then(/^I should be able to select all the radio buttons$/) do
+  expect(@app.css_selectors_page.radio_buttons).not_to be_empty
+end
+
+Then(/^I should be able to select all the radio buttons and checkboxes$/) do
+  pending
+  expect(@app.css_selectors_page.boxes_and_radio_buttons).not_to be_empty
+end
+
+Then(/^I should be able to select the about link element$/) do
+  expect(@app.css_selectors_page.about_link.text).to eq('About')
+end
+
+Then(/^I should be able to select the contact link element$/) do
+  expect(@app.css_selectors_page.contact_link.text).to eq('Contact')
+end
+
+Then(/^I should be able to select the continue button element$/) do
+  expect(@app.css_selectors_page.confirm_button.value).to eq('Continue')
+end
+
+# The following steps use capybara directly to drive the browser
+# --------------------------------------------------------------
+
+Given(/^I'm at the css selectors page$/) do
+  visit 'http://localhost:4567/cssselector'
+  expect(page).to have_content('CSS selector')
+end
+
+Then(/^I can select all href links$/) do
+  expect(page.all('a[href]')).not_to be_empty
+end
+
+Then(/^I can select all the radio buttons$/) do
+  expect(page.all("input[type='radio']")).not_to be_empty
+end
+
+Then(/^I can select all the radio buttons and checkboxes$/) do
+  pending
+  expect(page.all("input[type~='radio checkbox']")).not_to be_empty
+end
+
+Then(/^I can select the about link$/) do
+  expect(find("a[href*='about']").text).to eq('About')
+end
+
+Then(/^I can select the contact link$/) do
+  expect(find("a[href^='/con']").text).to eq('Contact')
+end
+
+Then(/^I can select the continue button element$/) do
+  expect(find("input[id$='mmit']").value).to eq('Continue')
+end

--- a/features/support/page_objects/quke/quke_app.rb
+++ b/features/support/page_objects/quke/quke_app.rb
@@ -16,4 +16,8 @@ class QukeApp
   def radio_button_page
     @last_page = QukeRadioButtonPage.new
   end
+
+  def css_selectors_page
+    @last_page = QukeCssSelectorsPage.new
+  end
 end

--- a/features/support/page_objects/quke/quke_css_selectors_page.rb
+++ b/features/support/page_objects/quke/quke_css_selectors_page.rb
@@ -1,0 +1,13 @@
+# CSS selectors page
+class QukeCssSelectorsPage < SitePrism::Page
+  set_url 'http://localhost:4567/cssselector'
+
+  element :title, 'h1'
+  element :about_link, "a[href*='about']"
+  element :contact_link, "a[href^='/con']"
+  element :confirm_button, "input[id$='mmit']"
+
+  elements :links, 'a[href]'
+  elements :radio_buttons, "input[type='radio']"
+  elements :boxes_and_radio_buttons, "input[type~='radio checkbox']"
+end

--- a/quke_demo_app/app.rb
+++ b/quke_demo_app/app.rb
@@ -65,3 +65,8 @@ post '/radiobutton' do
 
   erb :radio_button
 end
+
+get '/cssselector' do
+  @title = 'CSS selector'
+  erb :css_selector
+end

--- a/quke_demo_app/views/css_selector.erb
+++ b/quke_demo_app/views/css_selector.erb
@@ -1,0 +1,67 @@
+      <!-- Main jumbotron for a primary marketing message or call to action -->
+      <div class="jumbotron">
+        <h1><%= @title %></h1>
+        <p class="lead">Whether you're using <a href="https://github.com/natritmeyer/site_prism">Site Prism page objects</a>
+          or <a href="">Capybara</a> directly in your tests, they both rely on using CSS selectors to locate elements.
+          The steps behind <code>css_selectors.feature</code> are intended to provide a single source of examples for
+          the different ways you can use them to find elements. See the following for details</p>
+        <ul>
+          <li><code>features/quke/css_selectors.feature</code></li>
+          <li><code>features/step_definitions/quke/css_selector_steps.rb</code></li>
+          <li><code>quke_demo_app/views/css_selector.erb</code></li>
+        </ul>
+      </div>
+
+      <form class="css_selectors" id="css_selectors" action="/cssselector" accept-charset="UTF-8" method="post">
+        <fieldset>
+
+          <div id="form_group_organisation_type" role="group" aria-labelledby="groupLabel" class="form">
+            <label class="radio" for="organisation_limited_company">
+              <input id="organisation_limited_company" type="radio" value="WasteExemptionsShared::OrganisationType::LimitedCompany" name="enrollment[organisation_attributes][type]" />
+              Limited company
+            </label>
+            <label class="radio" for="organisation_limited_liability_partnership">
+              <input id="organisation_limited_liability_partnership" type="radio" value="WasteExemptionsShared::OrganisationType::LimitedLiabilityPartnership" name="enrollment[organisation_attributes][type]" />
+              Limited liability partnership
+            </label>
+            <label class="radio" for="organisation_partnership">
+              <input id="organisation_partnership" type="radio" value="WasteExemptionsShared::OrganisationType::Partnership" name="enrollment[organisation_attributes][type]" />
+              Partnership
+            </label>
+            <label class="radio" for="organisation_other">
+              <input id="organisation_other" type="radio" value="WasteExemptionsShared::OrganisationType::Other" name="enrollment[organisation_attributes][type]" />
+              Other (trust, club or public body)
+            </label>
+            <label class="radio" for="organisation_not_known">
+              <input id="organisation_not_known" type="radio" value="WasteExemptionsShared::OrganisationType::NotKnown" name="enrollment[organisation_attributes][type]" />
+              I don’t know
+            </label>
+          </div>
+
+          <div id="form_group_exemption_types" role="group" aria-labelledby="groupLabel" class="form-group">
+            <label class="block-label" for="fra2">
+              <input id="fra2" name="exemption[fra2]" type="checkbox" value="1" />
+              FRA2 Electrical cable service crossing a main river
+            </label>
+            <label class="block-label" for="fra3">
+              <input id="fra3" name="exemption[fra3]" type="checkbox" value="1" />
+              FRA3 Service crossing below the bed of a main river by directional drilling
+            </label>
+            <label class="block-label" for="fra4">
+              <input id="fra4" name="exemption[fra4]" type="checkbox" value="1" />
+              FRA4 Service crossings attached to the outside of existing structures over a main river
+            </label>
+          </div>
+
+          <div id="form_group_search_input" role="group" aria-labelledby="groupLabel" class="form-group">
+            <label class="form-label" for="search_input">
+              Enter your search
+            </label>
+            <input class="form-control form-control-char-25" aria-describedby="search-help" type="text" name="search_input" id="search_input"/>
+          </div>
+        </fieldset>
+
+        <div class="form-group">
+          <input type="submit" id="commit" name="commit" value="Continue" class="button"/>
+        </div>
+      </form>

--- a/quke_demo_app/views/index.erb
+++ b/quke_demo_app/views/index.erb
@@ -8,7 +8,8 @@
 
       <ul>
         <li><a href="/search">Search</a></li>
-        <li><a href="/radiobutton">Radio buttons</a></li>
+        <li><a href="/radiobutton">Radio button</a></li>
+        <li><a href="/cssselector">CSS selector</a></li>
       </ul>
 
       <%= erb '_partial_example'.to_sym %>


### PR DESCRIPTION
Whether you're using the page objects or Capybara directly, the key requirement in both is specifing how to select the elements of the page you're interested in.

This change adds a series of tests which demonstrate some of the ways CSS selectors can be specified in your tests.
