### PR TITLE
Move poltergeist driver options to Quke::Config

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -37,22 +37,7 @@ Capybara.app_host = $config.app_host
 # number of options for how to configure poltergeist, and we can even pass
 # on options to phantomjs to configure how it runs
 Capybara.register_driver :poltergeist do |app|
-  options = {
-    # Javascript errors will get re-raised in our tests causing them to fail
-    js_errors: true,
-    # How long in seconds we'll wait for response when communicating with
-    # Phantomjs
-    timeout: 30,
-    # When true debug output will be logged to STDERR (a terminal thing!)
-    debug: false,
-    # Options for phantomjs: Don't load images to help speed up the tests,
-    phantomjs_options: [
-      '--load-images=no',
-      '--disk-cache=false',
-      '--ignore-ssl-errors=yes'],
-    inspector: true
-  }
-  Capybara::Poltergeist::Driver.new(app, options)
+  Capybara::Poltergeist::Driver.new(app, $config.poltergeist_options)
 end
 
 # Here we are registering the selenium driver with capybara. By default

--- a/lib/quke/config.rb
+++ b/lib/quke/config.rb
@@ -28,15 +28,40 @@ module Quke
       @data['pause']
     end
 
+    # The hash returned from this method is intended to used in a call to
+    # Capybara::Poltergeist::Driver.new(app, options).
+    # There are a number of options for how to configure poltergeist, and we can
+    # even pass on options to phantomjs to configure how it runs
+    def poltergeist_options
+      {
+        # Javascript errors will get re-raised in our tests causing them to fail
+        js_errors: true,
+        # How long in seconds we'll wait for response when communicating with
+        # Phantomjs
+        timeout: 30,
+        # When true debug output will be logged to STDERR (a terminal thing!)
+        debug: false,
+        # Options for phantomjs: Don't load images to help speed up the tests,
+        phantomjs_options: [
+          '--load-images=no',
+          '--disk-cache=false',
+          '--ignore-ssl-errors=yes'],
+        inspector: true
+      }
+    end
+
     private
 
     # rubocop:disable Metrics/CyclomaticComplexity, Metrics/AbcSize
     def load_data
       yml_data = load_yml_data
       yml_data.merge(
-        'app_host' => (ENV['APP_HOST'] || yml_data['app_host'] || '').downcase.strip,
-        'driver' => (ENV['DRIVER'] || yml_data['driver'] || '').downcase.strip,
-        'pause' => (ENV['PAUSE'] || yml_data['pause'] || '0').downcase.strip.to_i
+        'app_host' => (ENV['APP_HOST'] || yml_data['app_host'] || '')
+                      .downcase.strip,
+        'driver' =>   (ENV['DRIVER'] || yml_data['driver'] || '')
+                      .downcase.strip,
+        'pause' =>    (ENV['PAUSE'] || yml_data['pause'] || '0')
+                      .downcase.strip.to_i
       )
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize


### PR DESCRIPTION
Rather than instantiating an options hash in `features/support/env.rb` which is then used in the call to `Capybara::Poltergeist::Driver.new(app, options)`, we have moved this to `lib/quke/config.rb`.

This will form the basis for the approach of passing options to drivers going forward (in preparation for browserstack integration), and gives us the flexibility in future to open these options up to users to configure.
