### PR TITLE
Clear up references to poltergeist and phantomjs

### DIFF
--- a/.config.example.yml
+++ b/.config.example.yml
@@ -7,7 +7,7 @@
 app_host: 'https://en.wikipedia.org/wiki'
 
 # Tells Quke which browser to use for testing. Choices are firefox, chrome and
-# poltergeist, with the default being poltergeist.
+# phantomjs, with the default being phantomjs.
 driver: chrome
 
 # Add a pause (in seconds) between steps so you can visually track how the

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The alternative to using the built in rake commands is to use configuration to d
 Quke recognises 3 options
 
 - **app_host** - Set the root url. You can then use it directly using Capybara with `visit('/Main_Page')` or `visit('/')` rather than having to repeat the full url each time
-- **driver** - Tell Quke which browser to use for testing. Options are *chrome*, *firefox* and *poltergeist* (*poltergeist* is the default)
+- **driver** - Tell Quke which browser to use for testing. Options are *chrome*, *firefox* and *phantomjs* (*phantomjs* is the default)
 - **pause** - Add a pause (in seconds) between steps so you can visually track how the browser is responding. The default is *0*
 
 For example

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,9 @@
-desc 'Runs the poltergeist task as default'
-task default: %w(poltergeist)
+desc 'Runs the phantomjs task as default'
+task default: %w(phantomjs)
 
-desc 'Run using Poltergeist headless browser'
-task :poltergeist do
+desc 'Run using Phantomjs headless browser /
+  (add PAUSE=1 for 1 sec pause between pages)'
+task :phantomjs do
   pause = ENV['PAUSE'].to_i ||= 0
   sh %( PAUSE=#{pause} bundle exec cucumber )
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -33,11 +33,12 @@ require_all 'lib'
 $config = Quke::Config.new
 Capybara.app_host = $config.app_host
 
-# Here we are registering the poltergeist driver with capybara. There are a
-# number of options for how to configure poltergeist, and we can even pass
-# on options to phantomjs to configure how it runs
-Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(app, $config.poltergeist_options)
+# Here we are registering the poltergeist driver with capybara. By default
+# poltergeist is setup to work with phantomjs hence we refer to it as :phantomjs
+# There are a number of options for how to configure poltergeist, and we can
+# even pass on options to phantomjs to configure how it runs
+Capybara.register_driver :phantomjs do |app|
+  Capybara::Poltergeist::Driver.new(app, $config.phantomjs_options)
 end
 
 # Here we are registering the selenium driver with capybara. By default
@@ -54,7 +55,7 @@ end
 
 # The choice of which browser to use for the tests is dependent on what the
 # environment variable DRIVER is set to. If not set we default to using
-# poltergeist
+# phantomjs (which in turn drives)
 # We capture the value as a global env var so if necessary choice of browser
 # can be referenced elsewhere, for example in any debug output.
 $driver = case $config.driver
@@ -63,7 +64,7 @@ $driver = case $config.driver
           when 'chrome'
             :chrome
           else
-            :poltergeist
+            :phantomjs
           end
 
 Capybara.default_driver = $driver

--- a/features/support/hooks/quke/after.rb
+++ b/features/support/hooks/quke/after.rb
@@ -1,9 +1,9 @@
 After('~@nonweb') do |scenario|
   if scenario.failed?
-    # Tell Cucumber to quit after first failing scenario when poltergeist is
-    # used. The expectation is that you are using poltergeist as part of your
+    # Tell Cucumber to quit after first failing scenario when phantomjs is
+    # used. The expectation is that you are using phantomjs as part of your
     # CI and therefore a fast response is better than a detailed response
-    if $driver == :poltergeist
+    if $driver == :phantomjs
       Cucumber.wants_to_quit = true
       return
     end

--- a/lib/quke/config.rb
+++ b/lib/quke/config.rb
@@ -34,9 +34,12 @@ module Quke
 
     # The hash returned from this method is intended to used in a call to
     # Capybara::Poltergeist::Driver.new(app, options).
-    # There are a number of options for how to configure poltergeist, and we can
-    # even pass on options to phantomjs to configure how it runs
-    def poltergeist_options
+    # There are a number of options for how to configure poltergeist which
+    # drives PhantomJS, and we can even pass on options to phantomjs to
+    # configure how it runs. We have named this function phantomjs_options
+    # because it us used to setup the Capybara.register_driver :phantomjs in
+    # features/support/env.rb
+    def phantomjs_options
       {
         # Javascript errors will get re-raised in our tests causing them to fail
         js_errors: true,


### PR DESCRIPTION
In Quke the Selenium web driver is used to drive either Firefox or Chrome, and Poltergeist drives the headless browser PhantomJS. However either in code or the instructions we reference 'firefox' and 'chrome' as browser options (not selenium), along with 'poltergeist'. To keep the naming consistent we should be using 'phantomjs' so this change updates references both in code and documentation to use 'phantomjs' (where appropriate).
