### PR TITLE
Remove bundler-audit from codeclimate config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,7 +1,5 @@
 ---
 engines:
-  bundler-audit:
-    enabled: true
   duplication:
     enabled: true
     config:

--- a/lib/quke/configuration.rb
+++ b/lib/quke/configuration.rb
@@ -32,6 +32,11 @@ module Quke #:nodoc:
       @data = load_data
     end
 
+    # Returns the value set for +features_folder+.
+    #
+    # This will be passed to Cucumber by Quke when it executes the tests. It
+    # tells Cucumber where the main features folder which contains the tests is
+    # located. If not set in the +.config.yml+ file it defaults to 'features'.
     def features_folder
       @data['features_folder']
     end

--- a/lib/quke/version.rb
+++ b/lib/quke/version.rb
@@ -1,3 +1,3 @@
 module Quke #:nodoc:
-  VERSION = '0.2.0'.freeze
+  VERSION = '0.2.1'.freeze
 end

--- a/quke.gemspec
+++ b/quke.gemspec
@@ -9,17 +9,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Alan Cruikshanks']
   spec.email         = ['alan.cruikshanks@environment-agency.gov.uk']
 
-  spec.summary       = 'A gem to simplify creating acceptance tests using /
-                        Cucumber'
-  spec.description   = 'Quke tries to simplify the process of writing and /
-                        running acceptance tests by setting up Cucumber for /
-                        you. /
-                        It handles the config to allow you to run your tests /
-                        in Firefox and Chrome, or the headless browser /
-                        PhantomJS. It also has out of the box setup for /
-                        using Browserstack automate. /
-                        This leaves you to focus on just your features and
-                        / steps.'
+  spec.summary       = 'A gem to simplify creating acceptance tests using Cucumber'
+  spec.description   = 'Quke tries to simplify the process of writing and running acceptance tests by setting up Cucumber for you. It handles the config to allow you to run your tests in Firefox and Chrome, or the headless browser PhantomJS. It also has out of the box setup for using Browserstack automate. This leaves you to focus on just your features and steps.'
   spec.homepage      = 'https://github.com/environmentagency/quke'
   spec.license       = 'Nonstandard'
 


### PR DESCRIPTION
The codeclimate bundler-audit engine only works if a Gemfile.lock is present. As we are now a gem this is ignored hence bundler-audit currently errors.
