### PR TITLE
Add Github_changelog_generator support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,62 @@
+# Change Log
+
+## [Unreleased](https://github.com/EnvironmentAgency/quke/tree/HEAD)
+
+[Full Changelog](https://github.com/EnvironmentAgency/quke/compare/v0.2.1...HEAD)
+
+**Merged pull requests:**
+
+- Add Rubygems version badge to README [\#33](https://github.com/EnvironmentAgency/quke/pull/33) ([Cruikshanks](https://github.com/Cruikshanks))
+
+## [v0.2.1](https://github.com/EnvironmentAgency/quke/tree/v0.2.1) (2016-10-05)
+[Full Changelog](https://github.com/EnvironmentAgency/quke/compare/v0.2.0...v0.2.1)
+
+**Merged pull requests:**
+
+- Remove bundler-audit from codeclimate config [\#32](https://github.com/EnvironmentAgency/quke/pull/32) ([Cruikshanks](https://github.com/Cruikshanks))
+
+## [v0.2.0](https://github.com/EnvironmentAgency/quke/tree/v0.2.0) (2016-10-04)
+[Full Changelog](https://github.com/EnvironmentAgency/quke/compare/v0.1.0...v0.2.0)
+
+**Merged pull requests:**
+
+- Convert to gem [\#31](https://github.com/EnvironmentAgency/quke/pull/31) ([Cruikshanks](https://github.com/Cruikshanks))
+
+## [v0.1.0](https://github.com/EnvironmentAgency/quke/tree/v0.1.0) (2016-08-01)
+**Closed issues:**
+
+- save\_and\_open\_page\(\) outputs to project root [\#12](https://github.com/EnvironmentAgency/quke/issues/12)
+- Use Capybara's implicit wait system [\#9](https://github.com/EnvironmentAgency/quke/issues/9)
+- Running tests against different environments [\#8](https://github.com/EnvironmentAgency/quke/issues/8)
+
+**Merged pull requests:**
+
+- Add browserstack support [\#30](https://github.com/EnvironmentAgency/quke/pull/30) ([Cruikshanks](https://github.com/Cruikshanks))
+- Add dependencyci badge to README.md [\#29](https://github.com/EnvironmentAgency/quke/pull/29) ([Cruikshanks](https://github.com/Cruikshanks))
+- Clear up references to poltergeist and phantomjs [\#28](https://github.com/EnvironmentAgency/quke/pull/28) ([Cruikshanks](https://github.com/Cruikshanks))
+- Add support for multiple config filespty message aborts the commit [\#26](https://github.com/EnvironmentAgency/quke/pull/26) ([Cruikshanks](https://github.com/Cruikshanks))
+- Move poltergeist driver options to Quke::Config [\#25](https://github.com/EnvironmentAgency/quke/pull/25) ([Cruikshanks](https://github.com/Cruikshanks))
+- Add support for a yaml \(.yml\) config file [\#24](https://github.com/EnvironmentAgency/quke/pull/24) ([Cruikshanks](https://github.com/Cruikshanks))
+- Add missing @quke tag to css\_selectors feature [\#23](https://github.com/EnvironmentAgency/quke/pull/23) ([Cruikshanks](https://github.com/Cruikshanks))
+- Add examples of CSS selectors to project [\#22](https://github.com/EnvironmentAgency/quke/pull/22) ([Cruikshanks](https://github.com/Cruikshanks))
+- Add explanation to demo pages on what tests show [\#21](https://github.com/EnvironmentAgency/quke/pull/21) ([Cruikshanks](https://github.com/Cruikshanks))
+- Replace title in README with new logo image [\#20](https://github.com/EnvironmentAgency/quke/pull/20) ([Cruikshanks](https://github.com/Cruikshanks))
+- Integrate quke with codeclimate [\#19](https://github.com/EnvironmentAgency/quke/pull/19) ([Cruikshanks](https://github.com/Cruikshanks))
+- Integrate with Travis-CI [\#18](https://github.com/EnvironmentAgency/quke/pull/18) ([Cruikshanks](https://github.com/Cruikshanks))
+- Stop saving to root when save\_and\_open\_page used [\#17](https://github.com/EnvironmentAgency/quke/pull/17) ([Cruikshanks](https://github.com/Cruikshanks))
+- Tidy up of the code [\#16](https://github.com/EnvironmentAgency/quke/pull/16) ([Cruikshanks](https://github.com/Cruikshanks))
+- Add example of interacting with radio-buttons [\#15](https://github.com/EnvironmentAgency/quke/pull/15) ([Cruikshanks](https://github.com/Cruikshanks))
+- Add embedded test website [\#14](https://github.com/EnvironmentAgency/quke/pull/14) ([Cruikshanks](https://github.com/Cruikshanks))
+- Enable Capybara implicit waits in Quke [\#13](https://github.com/EnvironmentAgency/quke/pull/13) ([Cruikshanks](https://github.com/Cruikshanks))
+- Make url endpoint to be tested configurable [\#11](https://github.com/EnvironmentAgency/quke/pull/11) ([Cruikshanks](https://github.com/Cruikshanks))
+- Expand readme with better documentation [\#7](https://github.com/EnvironmentAgency/quke/pull/7) ([Cruikshanks](https://github.com/Cruikshanks))
+- Add function to open page on fail [\#6](https://github.com/EnvironmentAgency/quke/pull/6) ([Cruikshanks](https://github.com/Cruikshanks))
+- Save custom quke args to global env vars [\#5](https://github.com/EnvironmentAgency/quke/pull/5) ([Cruikshanks](https://github.com/Cruikshanks))
+- Make use of hooks clearer in project [\#4](https://github.com/EnvironmentAgency/quke/pull/4) ([Cruikshanks](https://github.com/Cruikshanks))
+- Fix use of BROWSER instead of DRIVER in rake [\#3](https://github.com/EnvironmentAgency/quke/pull/3) ([Cruikshanks](https://github.com/Cruikshanks))
+- Structure project 2 avoid conflicts with upstream [\#2](https://github.com/EnvironmentAgency/quke/pull/2) ([Cruikshanks](https://github.com/Cruikshanks))
+- Rename env var BROWSER to DRIVER to fix Launchy [\#1](https://github.com/EnvironmentAgency/quke/pull/1) ([Cruikshanks](https://github.com/Cruikshanks))
+
+
+
+\* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,9 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rdoc/task'
+require 'github_changelog_generator/task'
+
+task :default => :spec
 
 RSpec::Core::RakeTask.new(:spec)
 
@@ -10,4 +13,5 @@ RDoc::Task.new do |doc|
   doc.rdoc_files = FileList.new %w[README.md lib LICENSE]
 end
 
-task :default => :spec
+GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+end

--- a/quke.gemspec
+++ b/quke.gemspec
@@ -89,4 +89,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.5'
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 0.6'
   spec.add_development_dependency 'simplecov', '~> 0.12'
+  spec.add_development_dependency 'github_changelog_generator', '~> 1.13'
 end


### PR DESCRIPTION
To help with ongoing maintenance and to see a simple list of changes we have added a changelog. However rather than manually write it we have added a dev dependency for [GitHub_Changelog_Generator](https://github.com/skywinder/github-changelog-generator/) and a new Rake task for generating the log.
