### PR TITLE
Fix Cucumber not loading lib/features correctly

### DIFF
--- a/lib/quke/cuke_runner.rb
+++ b/lib/quke/cuke_runner.rb
@@ -30,7 +30,15 @@ module Quke #:nodoc:
     def initialize(features_folder, args = [])
       @args = [
         features_folder,
-        '-r', 'lib/features',
+        # Because cucumber is called in the context of the executing script it
+        # will take the next argument from that position, not from where the gem
+        # currently sits. This means to Cucumber 'lib/features' doesn't exist,
+        # which means our env.rb never gets loaded. Instead we first have to
+        # determing where this file is running from when called, then we simply
+        # replace the last part of that result (which we know will be lib/quke)
+        # with lib/features. We then pass this full path to Cucumber so it can
+        # correctly find the folder holding our predefined env.rb file.
+        '-r', __dir__.sub!('lib/quke', 'lib/features'),
         '-r', features_folder
       ] + args
     end

--- a/lib/quke/version.rb
+++ b/lib/quke/version.rb
@@ -1,3 +1,3 @@
 module Quke #:nodoc:
-  VERSION = '0.2.1'.freeze
+  VERSION = '0.2.2'.freeze
 end

--- a/spec/quke/cuke_runner_spec.rb
+++ b/spec/quke/cuke_runner_spec.rb
@@ -1,7 +1,10 @@
 require 'spec_helper'
 
 RSpec.describe Quke::CukeRunner do
-  let(:default_args) { ['spec', '-r', 'lib/features', '-r', 'spec'] }
+  let(:default_args) do
+    features_folder = __dir__.sub!('spec/quke', 'lib/features')
+    ['spec', '-r', features_folder, '-r', 'spec']
+  end
   describe '#initialize' do
     context 'no additional Cucumber arguments passed' do
       let(:subject) { Quke::CukeRunner.new('spec') }


### PR DESCRIPTION
Because Cucumber is called in the context of the executing script (project) and not the gem, when it is telling Cucumber to reference `lib/features` Cucumber cannot see it. This means `env.rb` never gets loaded and therefore everything blows up.

This change corrects how we specify our default arguments, ensuring we correctly determine what the full path to the gems `lib/features` folder is, and passing that to Cucumber.
