### PR TITLE
Fix Quke not loading .config.yml correctly

### DIFF
--- a/lib/quke/configuration.rb
+++ b/lib/quke/configuration.rb
@@ -14,10 +14,7 @@ module Quke #:nodoc:
     # Returns the expected root location of where Quke expects to find the
     # the config file.
     def self.file_location
-      @file_location ||= File.expand_path(
-        "../../#{file_name}",
-        File.dirname(__FILE__)
-      )
+      @file_location ||= "#{Dir.pwd}/#{file_name}"
     end
 
     # Return the file name for the config file, either as set by the user in

--- a/lib/quke/version.rb
+++ b/lib/quke/version.rb
@@ -1,3 +1,3 @@
 module Quke #:nodoc:
-  VERSION = '0.2.2'.freeze
+  VERSION = '0.2.3'.freeze
 end


### PR DESCRIPTION
Similar to 544d546 (PR #35) Quke was not loading the .config.yml file as set by the user, again because it was thinking in terms of its location and not the calling projects. This change corrects that when calling `Quke::Configuration.file_location`.
