### PR TITLE
Change after_hook error to use config not assume

### DIFF
--- a/.config.example.yml
+++ b/.config.example.yml
@@ -20,6 +20,11 @@ driver: chrome
 # default is 0
 pause: 1
 
+# Specify whether Quke should stop all tests once an error occurs. Useful in
+# Continuous Integration (CI) environments where a quick Yes/No is preferable to
+# a detailed response.
+stop_on_error: 1
+
 # If you select the browserstack driver, there are a number of options you
 # can pass through to setup your browserstack tests, username and auth_key
 # being the critical ones.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,14 +26,29 @@ AllCops:
 Style/GlobalVars:
   Enabled: false
 
-# It is our opinion that classes are easier to read if a white space is
-# permitted between the class declaration and the first statement. Ditto the
-# last statement and the closing tag.
-Style/EmptyLinesAroundClassBody:
-  Enabled: false
-
-# It is our opinion that modules are easier to read if a white space is
-# permitted between the module declaration and the first statement. Ditto the
+# It is our opinion that code is easier to read if a white space is
+# permitted between the initial declaration and the first statement. Ditto the
 # last statement and the closing tag.
 Style/EmptyLinesAroundModuleBody:
   Enabled: false
+Style/EmptyLinesAroundClassBody:
+  Enabled: false
+Style/EmptyLinesAroundBlockBody:
+    Enabled: false
+
+# It is our opinion that in the specs 80 characters is too restrictive. Do to
+# the nature of some statements that it can be both difficult, and make more
+# simple statements complex if we are forced to split them over multiple lines.
+# Therefore we have upped this limit to 120 chars in the specs only.
+Metrics/LineLength:
+  Max: 120
+  Exclude:
+    - spec/quke/*.rb
+
+# Rubocop appears to flag `describe` blocks which are longer than 25 lines.
+# However it is our opinion that this is necessary in specs, for example when
+# describing a class, the body of the describe may well exceed 25 lines.
+# Therefore we have excluded this rule in the specs only.
+Metrics/BlockLength:
+  Exclude:
+    - spec/quke/*.rb

--- a/lib/features/support/after_hook.rb
+++ b/lib/features/support/after_hook.rb
@@ -6,14 +6,13 @@ After('~@nonweb') do |scenario|
     $fail_count ||= 0
     $fail_count = $fail_count + 1
 
-    # Tell Cucumber to quit after first failing scenario when phantomjs is
-    # used. The expectation is that you are using phantomjs as part of your
-    # CI and therefore a fast response is better than a detailed response.
-    # Experience has shown that should a major element of your service go
+    # Tell Cucumber to quit after first failing scenario when stop_on_error is
+    # true.
+    # Also experience has shown that should a major element of your service go
     # down all your tests will start failing which means you can be swamped
     # with output from `save_and_open_page`. Using a global count of the
     # number of fails, if it hits 5 it will cause cucumber to close.
-    if Quke::Quke.config.driver == :phantomjs || $fail_count >= 5
+    if Quke::Quke.config.stop_on_error || $fail_count >= 5
       Cucumber.wants_to_quit = true
     else
       # If we're not using poltergiest and the scenario has failed, we want

--- a/lib/quke.rb
+++ b/lib/quke.rb
@@ -10,6 +10,8 @@ module Quke #:nodoc:
   class Quke
 
     class << self
+      # Class level attribute which holds the instance of Quke::Configuration
+      # used for the current execution of Quke.
       attr_accessor :config
     end
 

--- a/lib/quke/configuration.rb
+++ b/lib/quke/configuration.rb
@@ -5,9 +5,20 @@ module Quke #:nodoc:
   # Manages all configuration for Quke.
   class Configuration
 
-    attr_reader :file_location, :data
+    # Access where the config file was loaded from for this instance of
+    # Quke::Configuration.
+    attr_reader :file_location
+
+    # Access the loaded config data object directly
+    attr_reader :data
 
     class << self
+      # Class level setter for the location of the config file.
+      #
+      # There will only be one for each execution of Quke and it does not
+      # support reading from another during execution. Hence we write this to
+      # the class level and all instances of Quke::Configuration then inherit
+      # this value.
       attr_writer :file_location
     end
 

--- a/lib/quke/configuration.rb
+++ b/lib/quke/configuration.rb
@@ -70,6 +70,17 @@ module Quke #:nodoc:
       @data['pause']
     end
 
+    # Return the value set for +stop_on_error+.
+    #
+    # Specify whether Quke should stop all tests once an error occurs. Useful in
+    # Continuous Integration (CI) environments where a quick Yes/No is
+    # preferable to a detailed response.
+    def stop_on_error
+      # This use of Yaml.load to convert a string to a boolean comes from
+      # http://stackoverflow.com/a/21804027/6117745
+      YAML.load(@data['stop_on_error'])
+    end
+
     # Return the hash of +browserstack+ options.
     #
     # If you select the browserstack driver, there are a number of options you
@@ -130,9 +141,10 @@ module Quke #:nodoc:
     def default_data!(data)
       data.merge(
         'features_folder' => (data['features'] || 'features').downcase.strip,
-        'app_host' => (data['app_host'] || '').downcase.strip,
-        'driver' =>   (data['driver'] || 'phantomjs').downcase.strip,
-        'pause' =>    (data['pause'] || '0').to_s.downcase.strip.to_i
+        'app_host' =>        (data['app_host'] || '').downcase.strip,
+        'driver' =>          (data['driver'] || 'phantomjs').downcase.strip,
+        'pause' =>           (data['pause'] || '0').to_s.downcase.strip.to_i,
+        'stop_on_error' =>   (data['stop_on_error'] || 'false').to_s.downcase.strip
       )
     end
     # rubocop:enable Metrics/AbcSize

--- a/lib/quke/cuke_runner.rb
+++ b/lib/quke/cuke_runner.rb
@@ -5,6 +5,7 @@ module Quke #:nodoc:
   # Handles executing Cucumber, including sorting the arguments we pass to it
   class CukeRunner
 
+    # # Access the arguments used by Quke when it was executed
     attr_reader :args
 
     # When an instance of CukeRunner is initialized it will take the arguments

--- a/lib/quke/driver_registration.rb
+++ b/lib/quke/driver_registration.rb
@@ -8,12 +8,20 @@ module Quke #:nodoc:
   # Capybara.
   class DriverRegistration
 
+    # Access the instance of Quke::Configuration passed to this instance of
+    # Quke::DriverRegistration when it was initialized.
     attr_reader :config
 
+    # Instantiate an instance of Quke::DriverRegistration.
+    #
+    # It expects an instance of Quke::Configuration which will detail the driver
+    # to be used and any related options
     def initialize(config)
       @config = config
     end
 
+    # When called registers the driver specified in the instance of
+    # Quke::Configuration currently being used by Quke.
     def register
       case @config.driver
       when 'firefox'

--- a/lib/quke/version.rb
+++ b/lib/quke/version.rb
@@ -1,3 +1,3 @@
 module Quke #:nodoc:
-  VERSION = '0.2.3'.freeze
+  VERSION = '0.2.4'.freeze
 end

--- a/spec/data/.as_string.yml
+++ b/spec/data/.as_string.yml
@@ -1,0 +1,5 @@
+# In our tests we're checking that if a non-string value is specified as a
+# string Freakin::Configuration can still handle it
+pause: '1'
+
+stop_on_error: true

--- a/spec/data/.pause.yml
+++ b/spec/data/.pause.yml
@@ -1,3 +1,0 @@
-# In the test we're checking that is the pause value is specified as a string
-# Freakin::Configuration can still handle it
-pause: '1'

--- a/spec/data/.simple.yml
+++ b/spec/data/.simple.yml
@@ -5,6 +5,7 @@ features: 'spec'
 app_host: 'http://localhost:4567'
 driver: chrome
 pause: 1
+stop_on_error: true
 
 browserstack:
   username: jdoe

--- a/spec/quke/configuration_spec.rb
+++ b/spec/quke/configuration_spec.rb
@@ -66,8 +66,31 @@ RSpec.describe Quke::Configuration do
 
     context 'when in the config file as a string' do
       it 'matches the config file' do
-        Quke::Configuration.file_location = data_path('.pause.yml')
+        Quke::Configuration.file_location = data_path('.as_string.yml')
         expect(subject.pause).to eq(1)
+      end
+    end
+  end
+
+  describe '#stop_on_error', focus: true do
+    context 'when NOT specified in the config file' do
+      it 'defaults to false' do
+        Quke::Configuration.file_location = data_path('.no_file.yml')
+        expect(subject.stop_on_error).to eq(false)
+      end
+    end
+
+    context 'when specified in config file' do
+      it 'matches the config file' do
+        Quke::Configuration.file_location = data_path('.simple.yml')
+        expect(subject.stop_on_error).to eq(true)
+      end
+    end
+
+    context 'when in the config file as a string' do
+      it 'matches the config file' do
+        Quke::Configuration.file_location = data_path('.as_string.yml')
+        expect(subject.stop_on_error).to eq(true)
       end
     end
   end

--- a/spec/quke/configuration_spec.rb
+++ b/spec/quke/configuration_spec.rb
@@ -138,9 +138,11 @@ RSpec.describe Quke::Configuration do
   describe '#to_s' do
     it 'return the values held by the instance and not an instance ID' do
       Quke::Configuration.file_location = data_path('.no_file.yml')
+      # rubocop:disable Style/StringLiterals
       expect(subject.to_s).to eq(
         "{\"features_folder\"=>\"features\", \"app_host\"=>\"\", \"driver\"=>\"phantomjs\", \"pause\"=>0, \"browserstack\"=>{\"username\"=>\"\", \"auth_key\"=>\"\"}}"
       )
+      # rubocop:enable Style/StringLiterals
     end
   end
 


### PR DESCRIPTION
This will resolve issue #41, which highlights that **Quke's** assumption that CI is only being when the **phantomjs** driver is selected is restrictive and incorrect.

Users may wish to use other drivers in a CI environment, for example [XVFB](https://en.wikipedia.org/wiki/Xvfb) with Chrome. Therefore this change removes the assumption in the `after_hook.rb` logic to fail immediately if **phantomjs** is being used, to instead drive the behaviour off a config flag.