### PR TITLE
Fix rspec focus label left in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,16 @@ git:
 # https://docs.travis-ci.com/user/languages/ruby#Caching-Bundler
 cache: bundler
 
+# Using the ability to customise the Travis build to check for 'focus' labels
+# i.e. labels used when working on a spec but which we don't want appearing in
+# the final commit to master
+# Reworking of http://stackoverflow.com/a/30495279/6117745
+# If grep returns 0 (match found), test 0 -eq 1 will return 1.
+# If grep returns 1 (no match found), test 1 -eq 1 will return 0.
+# If grep returns 2 (error), test 2 -eq 1 will return 1.
+before_script: >-
+  echo "Checking for use of 'focus' labels in specs" && grep -r --include="*_spec.rb" "focus: true" spec/; test $? -eq 1
+
 # This section was added as per https://docs.travis-ci.com/user/code-climate/
 # To protect our codeclimate stats rather than adding the Codeclimate API key for ea-area_lookup
 # in the open we used this guide https://docs.travis-ci.com/user/encryption-keys/ to encryt the

--- a/lib/quke/version.rb
+++ b/lib/quke/version.rb
@@ -1,3 +1,3 @@
 module Quke #:nodoc:
-  VERSION = '0.2.4'.freeze
+  VERSION = '0.2.5'.freeze
 end

--- a/spec/quke/configuration_spec.rb
+++ b/spec/quke/configuration_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Quke::Configuration do
     end
   end
 
-  describe '#stop_on_error', focus: true do
+  describe '#stop_on_error' do
     context 'when NOT specified in the config file' do
       it 'defaults to false' do
         Quke::Configuration.file_location = data_path('.no_file.yml')
@@ -140,7 +140,7 @@ RSpec.describe Quke::Configuration do
       Quke::Configuration.file_location = data_path('.no_file.yml')
       # rubocop:disable Style/StringLiterals
       expect(subject.to_s).to eq(
-        "{\"features_folder\"=>\"features\", \"app_host\"=>\"\", \"driver\"=>\"phantomjs\", \"pause\"=>0, \"browserstack\"=>{\"username\"=>\"\", \"auth_key\"=>\"\"}}"
+        "{\"features_folder\"=>\"features\", \"app_host\"=>\"\", \"driver\"=>\"phantomjs\", \"pause\"=>0, \"stop_on_error\"=>\"false\", \"browserstack\"=>{\"username\"=>\"\", \"auth_key\"=>\"\"}}"
       )
       # rubocop:enable Style/StringLiterals
     end


### PR DESCRIPTION
This change removes a focus label left in a test in the last PR #42, as per issue #43.

It also updates `.travis.yml` to add a new check for focus labels to attempt to prevent it happening again. If the check finds a match it will break the build.