### PR TITLE
Expose Capybara default_max_wait_time config value

### DIFF
--- a/lib/features/support/env.rb
+++ b/lib/features/support/env.rb
@@ -16,6 +16,11 @@ driver = driver_reg.register(Quke::Quke.config.driver)
 Capybara.default_driver = driver
 Capybara.javascript_driver = driver
 
+# default_max_wait_time is the maximum time Capybara will wait for an element
+# to appear. You may wish to override it if you are having to deal with a slow
+# or unresponsive web site.
+Capybara.default_max_wait_time = Quke::Quke.config.max_wait_time
+
 # By default Capybara will try to boot a rack application automatically. This
 # switches off Capybara's rack server as we are running against a remote
 # application.

--- a/lib/quke/configuration.rb
+++ b/lib/quke/configuration.rb
@@ -92,6 +92,19 @@ module Quke #:nodoc:
       YAML.load(@data['stop_on_error'])
     end
 
+    # Return the value for +max_wait_time+
+    #
+    # +max_wait_time+ is the time Capybara will spend waiting for an element
+    # to appear. It's default is normally 2 seconds but you may want to increase
+    # this is you are having to deal with a site that is not performant or prone
+    # to delays.
+    #
+    # If the value is not set in config file, it will default to whatever is the
+    # current Capybara value for default_max_wait_time.
+    def max_wait_time
+      @data['max_wait_time']
+    end
+
     # Return the hash of +browserstack+ options.
     #
     # If you select the browserstack driver, there are a number of options you
@@ -138,16 +151,19 @@ module Quke #:nodoc:
     end
 
     # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/CyclomaticComplexity
     def default_data!(data)
       data.merge(
         'features_folder' => (data['features'] || 'features').downcase.strip,
         'app_host' =>        (data['app_host'] || '').downcase.strip,
         'driver' =>          (data['driver'] || 'phantomjs').downcase.strip,
         'pause' =>           (data['pause'] || '0').to_s.downcase.strip.to_i,
-        'stop_on_error' =>   (data['stop_on_error'] || 'false').to_s.downcase.strip
+        'stop_on_error' =>   (data['stop_on_error'] || 'false').to_s.downcase.strip,
+        'max_wait_time' =>   (data['max_wait_time'] || Capybara.default_max_wait_time).to_s.downcase.strip.to_i
       )
     end
     # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     # rubocop:disable Metrics/MethodLength
     def browserstack_data(data)

--- a/spec/data/.as_string.yml
+++ b/spec/data/.as_string.yml
@@ -3,6 +3,7 @@
 pause: '1'
 
 stop_on_error: 'true'
+max_wait_time: '3'
 
 proxy:
   port: '8080'

--- a/spec/data/.simple.yml
+++ b/spec/data/.simple.yml
@@ -6,6 +6,7 @@ app_host: 'http://localhost:4567'
 driver: chrome
 pause: 1
 stop_on_error: true
+max_wait_time: 3
 
 proxy:
   host: '10.10.2.70'

--- a/spec/quke/configuration_spec.rb
+++ b/spec/quke/configuration_spec.rb
@@ -95,6 +95,29 @@ RSpec.describe Quke::Configuration do
     end
   end
 
+  describe '#max_wait_time' do
+    context 'when NOT specified in the config file' do
+      it 'defaults to whatever the Capybara default is' do
+        Quke::Configuration.file_location = data_path('.no_file.yml')
+        expect(subject.max_wait_time).to eq(Capybara.default_max_wait_time)
+      end
+    end
+
+    context 'when specified in config file' do
+      it 'matches the config file' do
+        Quke::Configuration.file_location = data_path('.simple.yml')
+        expect(subject.max_wait_time).to eq(3)
+      end
+    end
+
+    context 'when in the config file as a string' do
+      it 'matches the config file' do
+        Quke::Configuration.file_location = data_path('.as_string.yml')
+        expect(subject.max_wait_time).to eq(3)
+      end
+    end
+  end
+
   describe '#proxy' do
     context 'when NOT specified in the config file' do
       it 'defaults to a blank values' do
@@ -168,7 +191,7 @@ RSpec.describe Quke::Configuration do
       Quke::Configuration.file_location = data_path('.no_file.yml')
       # rubocop:disable Style/StringLiterals
       expect(subject.to_s).to eq(
-        "{\"features_folder\"=>\"features\", \"app_host\"=>\"\", \"driver\"=>\"phantomjs\", \"pause\"=>0, \"stop_on_error\"=>\"false\", \"browserstack\"=>{\"username\"=>\"\", \"auth_key\"=>\"\"}, \"proxy\"=>{\"host\"=>\"\", \"port\"=>0, \"no_proxy\"=>\"\"}}"
+        "{\"features_folder\"=>\"features\", \"app_host\"=>\"\", \"driver\"=>\"phantomjs\", \"pause\"=>0, \"stop_on_error\"=>\"false\", \"max_wait_time\"=>2, \"browserstack\"=>{\"username\"=>\"\", \"auth_key\"=>\"\"}, \"proxy\"=>{\"host\"=>\"\", \"port\"=>0, \"no_proxy\"=>\"\"}}"
       )
       # rubocop:enable Style/StringLiterals
     end


### PR DESCRIPTION
Not everyone gets to test responsive, performant web sites and therefore may have pages where elements take some time to appear.

Capybara is smart enough to include functionality that waits a certain time when attempting to find elements (https://github.com/teamcapybara/capybara/blob/master/README.md#asynchronous-javascript-ajax-and-friends). So for example if you have

```ruby
click_link("change details")
```

Capybara will keep attempting to find the link up to the value set by `default_max_wait_time` (which defaults to 2 seconds). If you are testing a web site that has elements which take longer than this to load you're tests may keep failing. Therefore to increase the flexibility of Quke this change exposes this value to allow users to configure it. This is done through the `config.yml` mechanism.