### PR TITLE
Add ability to set user-agent to use

### DIFF
--- a/.config.example.yml
+++ b/.config.example.yml
@@ -31,6 +31,14 @@ stop_on_error: 1
 # elements that take some time to load you can increase this default.
 max_wait_time: 5
 
+# Tell the driver Quke is using to send a different user-agent value to the site
+# under test. Useful if you want the underlying driver to spoof what kind of
+# browser the request is coming from. For example you may want to pretend to be
+# a mobile browser so you can check what you get back versus the desktop
+# version. Or you want to pretend to be another kind of browser, because the one
+# you have is not supported by the site.
+user_agent: "Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)"
+
 # Anything you place under the 'custom' node in the `.config.yml` file will be
 # available within your steps and page objects by calling
 # `Quke::Quke.config.custom`. So using the example below we could access its

--- a/lib/features/support/before_hook.rb
+++ b/lib/features/support/before_hook.rb
@@ -1,0 +1,24 @@
+require 'quke/configuration'
+
+Before('~@nonweb') do
+  # We have to make a special case for phantomjs when it comes to implementing
+  # the ability to override the user agent. Unlike the selinium backed drivers
+  # specifying the user agent is not part of the arguments we pass in when
+  # initialising the driver. Instead its something we call on the driver once
+  # its been instantiated
+  # https://github.com/teampoltergeist/poltergeist#manipulating-request-headers
+  # That might not have been so bad, the folks behind poltergeist have also
+  # made it so that custom changes to the header only last for as long as the
+  # test is running. Once a test finishes, the changes are lost.
+  # Hence the only way we can ensure its set across all tests is by making use
+  # of the Before hook, and adding the User-Agent header each time.
+  if Quke::Quke.config.driver == 'phantomjs'
+    unless Quke::Quke.config.user_agent.empty?
+      page.driver.add_header(
+        'User-Agent',
+        Quke::Quke.config.user_agent,
+        permanent: true
+      )
+    end
+  end
+end

--- a/lib/quke/configuration.rb
+++ b/lib/quke/configuration.rb
@@ -105,6 +105,17 @@ module Quke #:nodoc:
       @data['max_wait_time']
     end
 
+    # Return the value set for +user_agent+.
+    #
+    # Useful if you want the underlying driver to spoof what kind of browser the
+    # request is coming from. For example you may want to pretend to be a mobile
+    # browser so you can check what you get back versus the desktop version. Or
+    # you want to pretend to be another kind of browser, because the one you
+    # have is not supported by the site.
+    def user_agent
+      @data['user_agent']
+    end
+
     # Return the hash of +browserstack+ options.
     #
     # If you select the browserstack driver, there are a number of options you
@@ -165,6 +176,7 @@ module Quke #:nodoc:
         'pause' =>           (data['pause'] || '0').to_s.downcase.strip.to_i,
         'stop_on_error' =>   (data['stop_on_error'] || 'false').to_s.downcase.strip,
         'max_wait_time' =>   (data['max_wait_time'] || Capybara.default_max_wait_time).to_s.downcase.strip.to_i,
+        'user_agent' =>      (data['user_agent'] || '').strip,
         'custom' =>          (data['custom'] || nil)
       )
     end

--- a/lib/quke/driver_configuration.rb
+++ b/lib/quke/driver_configuration.rb
@@ -120,7 +120,8 @@ module Quke #:nodoc:
     #       browser: :chrome,
     #       switches: [
     #         "--proxy-server=localhost:8080",
-    #         "--proxy-bypass-list=127.0.0.1,192.168.0.1"
+    #         "--proxy-bypass-list=127.0.0.1,192.168.0.1",
+    #         "--user-agent=Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)"
     #       ]
     #     )
     #
@@ -145,6 +146,8 @@ module Quke #:nodoc:
       result.push("--proxy-server=#{host}:#{port}") if config.use_proxy?
       result.push("--proxy-bypass-list=#{no_proxy}") unless config.proxy['no_proxy'].empty?
 
+      result.push("--user-agent=#{config.user_agent}") unless config.user_agent.empty?
+
       result
     end
     # rubocop:enable Metrics/AbcSize
@@ -160,6 +163,7 @@ module Quke #:nodoc:
     #       http: "10.10.2.70:8080",
     #       ssl: "10.10.2.70:8080"
     #     )
+    #     my_profile['general.useragent.override'] = "Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)"
     #     Capybara::Selenium::Driver.new(
     #       app,
     #       profile: my_profile
@@ -189,6 +193,8 @@ module Quke #:nodoc:
       settings[:no_proxy] = no_proxy unless config.proxy['no_proxy'].empty?
 
       profile.proxy = Selenium::WebDriver::Proxy.new(settings) if config.use_proxy?
+
+      profile['general.useragent.override'] = config.user_agent unless config.user_agent.empty?
 
       profile
     end

--- a/spec/data/.user_agent.yml
+++ b/spec/data/.user_agent.yml
@@ -1,0 +1,1 @@
+user_agent: "Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)"

--- a/spec/quke/configuration_spec.rb
+++ b/spec/quke/configuration_spec.rb
@@ -118,6 +118,22 @@ RSpec.describe Quke::Configuration do
     end
   end
 
+  describe '#user_agent' do
+    context 'when NOT specified in the config file' do
+      it "defaults to ''" do
+        Quke::Configuration.file_location = data_path('.no_file.yml')
+        expect(subject.user_agent).to eq('')
+      end
+    end
+
+    context 'when specified in the config file' do
+      it 'matches the config file' do
+        Quke::Configuration.file_location = data_path('.user_agent.yml')
+        expect(subject.user_agent).to eq('Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)')
+      end
+    end
+  end
+
   describe '#proxy' do
     context 'when NOT specified in the config file' do
       it 'defaults to blank values' do
@@ -245,7 +261,7 @@ RSpec.describe Quke::Configuration do
       Quke::Configuration.file_location = data_path('.no_file.yml')
       # rubocop:disable Style/StringLiterals
       expect(subject.to_s).to eq(
-        "{\"features_folder\"=>\"features\", \"app_host\"=>\"\", \"driver\"=>\"phantomjs\", \"pause\"=>0, \"stop_on_error\"=>\"false\", \"max_wait_time\"=>2, \"custom\"=>nil, \"browserstack\"=>{\"username\"=>\"\", \"auth_key\"=>\"\"}, \"proxy\"=>{\"host\"=>\"\", \"port\"=>0, \"no_proxy\"=>\"\"}}"
+        "{\"features_folder\"=>\"features\", \"app_host\"=>\"\", \"driver\"=>\"phantomjs\", \"pause\"=>0, \"stop_on_error\"=>\"false\", \"max_wait_time\"=>2, \"user_agent\"=>\"\", \"custom\"=>nil, \"browserstack\"=>{\"username\"=>\"\", \"auth_key\"=>\"\"}, \"proxy\"=>{\"host\"=>\"\", \"port\"=>0, \"no_proxy\"=>\"\"}}"
       )
       # rubocop:enable Style/StringLiterals
     end

--- a/spec/quke/driver_configuration_spec.rb
+++ b/spec/quke/driver_configuration_spec.rb
@@ -74,6 +74,20 @@ RSpec.describe Quke::DriverConfiguration do
       end
     end
 
+    context 'a user agent has been set in the .config.yml' do
+      it 'is not in the array returned. Unlike the other drivers we can only override the user agent when registering the driver' do
+        Quke::Configuration.file_location = data_path('.user_agent.yml')
+        config = Quke::Configuration.new
+        expect(Quke::DriverConfiguration.new(config).phantomjs).to eq(
+          [
+            '--load-images=no',
+            '--disk-cache=false',
+            '--ignore-ssl-errors=yes'
+          ]
+        )
+      end
+    end
+
   end
 
   describe '#chrome' do
@@ -102,6 +116,18 @@ RSpec.describe Quke::DriverConfiguration do
           [
             "--proxy-server=#{config.proxy['host']}:#{config.proxy['port']}",
             '--proxy-bypass-list=127.0.0.1;192.168.0.1'
+          ]
+        )
+      end
+    end
+
+    context 'a user agent has been set in the .config.yml' do
+      it 'returns an array containing the specified user-agent' do
+        Quke::Configuration.file_location = data_path('.user_agent.yml')
+        config = Quke::Configuration.new
+        expect(Quke::DriverConfiguration.new(config).chrome).to eq(
+          [
+            "--user-agent=#{config.user_agent}"
           ]
         )
       end
@@ -154,6 +180,22 @@ RSpec.describe Quke::DriverConfiguration do
         expect(preferences).to include('user_pref("network.proxy.http", "10.10.2.70")')
         expect(preferences).to include('user_pref("network.proxy.http_port", 8080)')
         expect(preferences).to include('user_pref("network.proxy.no_proxies_on", "127.0.0.1,192.168.0.1")')
+      end
+    end
+
+    context 'a user agent has been set in the .config.yml' do
+      it 'returns an array containing the specified user-agent' do
+        Quke::Configuration.file_location = data_path('.user_agent.yml')
+        config = Quke::Configuration.new
+        profile = Quke::DriverConfiguration.new(config).firefox
+
+        # See spec/helpers.rb#read_profile_preferences for details of why we
+        # need to test the profile's properties in this way
+        preferences = read_profile_preferences(profile)
+
+        expect(preferences).to include(
+          'user_pref("general.useragent.override", "Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)")'
+        )
       end
     end
 


### PR DESCRIPTION
https://github.com/DEFRA/quke/issues/58

This change allows users to specify the user agent a driver should use via the `config.yml`. This will only apply to the **Firefox**, **Chrome** and **PhantomJS** drivers.

The changes involved taking the argument passed in and
correctly configuring the underlying driver to use it. In the case of
**Firefox** this involved updating the profile. For **Chrome** it was
simply adding an additional flag.

**PhantomJS** proved to be more of a problem. You have to add a header
via **Poltergiest**, however it only last for the current session i.e
test. This means before every scenario you have to keep adding it back
in.

This meant a new `before()` hook was added to handle this.

Other changes include tests and documentation.