### PR TITLE
Add option to override js_errors for phantomjs

### DIFF
--- a/.config.example.yml
+++ b/.config.example.yml
@@ -39,6 +39,15 @@ max_wait_time: 5
 # you have is not supported by the site.
 user_agent: "Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)"
 
+# Currently only supported when using the phantomjs driver (ignored by the
+# others). In phantomjs if a site has a javascript error we can configure it
+# to throw an error which will cause the test to fail. Quke by default sets this
+# to true, however you can override it by setting this flag to false.
+# For example you may be dealing with a legacy site and JavaScript errors
+# are out of your scope. You still want to test other aspects of the site
+# but not let these errors prevent you from using phantomjs.
+javascript_errors: false
+
 # Anything you place under the 'custom' node in the `.config.yml` file will be
 # available within your steps and page objects by calling
 # `Quke::Quke.config.custom`. So using the example below we could access its

--- a/lib/quke/configuration.rb
+++ b/lib/quke/configuration.rb
@@ -116,6 +116,19 @@ module Quke #:nodoc:
       @data['user_agent']
     end
 
+    # Return the value set for +javascript_errors+.
+    #
+    # Currently only supported when using the phantomjs driver (ignored by the
+    # others). In phantomjs if a site has a javascript error we can configure it
+    # to throw an error which will cause the test to fail. Quke by default sets
+    # this to true, however you can override it by setting this flag to false.
+    # For example you may be dealing with a legacy site and JavaScript errors
+    # are out of your scope. You still want to test other aspects of the site
+    # but not let these errors prevent you from using phantomjs.
+    def javascript_errors
+      @data['javascript_errors']
+    end
+
     # Return the hash of +browserstack+ options.
     #
     # If you select the browserstack driver, there are a number of options you
@@ -170,14 +183,21 @@ module Quke #:nodoc:
     # rubocop:disable Metrics/PerceivedComplexity
     def default_data!(data)
       data.merge(
-        'features_folder' => (data['features'] || 'features').downcase.strip,
-        'app_host' =>        (data['app_host'] || '').downcase.strip,
-        'driver' =>          (data['driver'] || 'phantomjs').downcase.strip,
-        'pause' =>           (data['pause'] || '0').to_s.downcase.strip.to_i,
-        'stop_on_error' =>   (data['stop_on_error'] || 'false').to_s.downcase.strip,
-        'max_wait_time' =>   (data['max_wait_time'] || Capybara.default_max_wait_time).to_s.downcase.strip.to_i,
-        'user_agent' =>      (data['user_agent'] || '').strip,
-        'custom' =>          (data['custom'] || nil)
+        'features_folder' =>   (data['features'] || 'features').downcase.strip,
+        'app_host' =>          (data['app_host'] || '').downcase.strip,
+        'driver' =>            (data['driver'] || 'phantomjs').downcase.strip,
+        'pause' =>             (data['pause'] || '0').to_s.downcase.strip.to_i,
+        'stop_on_error' =>     (data['stop_on_error'] || 'false').to_s.downcase.strip,
+        'max_wait_time' =>     (data['max_wait_time'] || Capybara.default_max_wait_time).to_s.downcase.strip.to_i,
+        'user_agent' =>        (data['user_agent'] || '').strip,
+        # Because we want to default to 'true', but allow users to override it
+        # with 'false' it causes us to mess with the logic. Essentially if the
+        # user does enter false (either as a string or as a boolean) the result
+        # will be 'true', so we flip it back to 'false' with !.
+        # Else the condition fails and we get 'false', which when flipped gives
+        # us 'true', which is what we want the default value to be
+        'javascript_errors' => !(data['javascript_errors'].to_s.downcase.strip == 'false'),
+        'custom' =>            (data['custom'] || nil)
       )
     end
     # rubocop:enable Metrics/AbcSize

--- a/lib/quke/driver_configuration.rb
+++ b/lib/quke/driver_configuration.rb
@@ -52,7 +52,7 @@ module Quke #:nodoc:
       # https://github.com/teampoltergeist/poltergeist#customization
       {
         # Javascript errors will get re-raised in our tests causing them to fail
-        js_errors: true,
+        js_errors: config.javascript_errors,
         # How long in seconds we'll wait for response when communicating with
         # Phantomjs
         timeout: 30,

--- a/lib/quke/version.rb
+++ b/lib/quke/version.rb
@@ -1,3 +1,3 @@
 module Quke #:nodoc:
-  VERSION = '0.3.1'.freeze
+  VERSION = '0.3.2'.freeze
 end

--- a/spec/data/.as_string.yml
+++ b/spec/data/.as_string.yml
@@ -4,6 +4,7 @@ pause: '1'
 
 stop_on_error: 'true'
 max_wait_time: '3'
+javascript_errors: 'false'
 
 proxy:
   port: '8080'

--- a/spec/data/.javascript_errors.yml
+++ b/spec/data/.javascript_errors.yml
@@ -1,0 +1,1 @@
+javascript_errors: false

--- a/spec/quke/configuration_spec.rb
+++ b/spec/quke/configuration_spec.rb
@@ -134,6 +134,29 @@ RSpec.describe Quke::Configuration do
     end
   end
 
+  describe '#javascrip_errors' do
+    context 'when NOT specified in the config file' do
+      it 'defaults to true' do
+        Quke::Configuration.file_location = data_path('.no_file.yml')
+        expect(subject.javascript_errors).to eq(true)
+      end
+    end
+
+    context 'when specified in config file' do
+      it 'matches the config file' do
+        Quke::Configuration.file_location = data_path('.javascript_errors.yml')
+        expect(subject.javascript_errors).to eq(false)
+      end
+    end
+
+    context 'when in the config file as a string' do
+      it 'matches the config file' do
+        Quke::Configuration.file_location = data_path('.as_string.yml')
+        expect(subject.javascript_errors).to eq(false)
+      end
+    end
+  end
+
   describe '#proxy' do
     context 'when NOT specified in the config file' do
       it 'defaults to blank values' do
@@ -260,8 +283,9 @@ RSpec.describe Quke::Configuration do
     it 'return the values held by the instance and not an instance ID' do
       Quke::Configuration.file_location = data_path('.no_file.yml')
       # rubocop:disable Style/StringLiterals
+      puts subject.to_s
       expect(subject.to_s).to eq(
-        "{\"features_folder\"=>\"features\", \"app_host\"=>\"\", \"driver\"=>\"phantomjs\", \"pause\"=>0, \"stop_on_error\"=>\"false\", \"max_wait_time\"=>2, \"user_agent\"=>\"\", \"custom\"=>nil, \"browserstack\"=>{\"username\"=>\"\", \"auth_key\"=>\"\"}, \"proxy\"=>{\"host\"=>\"\", \"port\"=>0, \"no_proxy\"=>\"\"}}"
+        "{\"features_folder\"=>\"features\", \"app_host\"=>\"\", \"driver\"=>\"phantomjs\", \"pause\"=>0, \"stop_on_error\"=>\"false\", \"max_wait_time\"=>2, \"user_agent\"=>\"\", \"javascript_errors\"=>true, \"custom\"=>nil, \"browserstack\"=>{\"username\"=>\"\", \"auth_key\"=>\"\"}, \"proxy\"=>{\"host\"=>\"\", \"port\"=>0, \"no_proxy\"=>\"\"}}"
       )
       # rubocop:enable Style/StringLiterals
     end

--- a/spec/quke/driver_configuration_spec.rb
+++ b/spec/quke/driver_configuration_spec.rb
@@ -41,6 +41,24 @@ RSpec.describe Quke::DriverConfiguration do
       end
     end
 
+    context 'user has set javascript_errors to false in the .config.yml' do
+      it "returns a hash where js_errors is set to 'false'" do
+        Quke::Configuration.file_location = data_path('.javascript_errors.yml')
+        config = Quke::Configuration.new
+        expect(Quke::DriverConfiguration.new(config).poltergeist).to eq(
+          js_errors: false,
+          timeout: 30,
+          debug: false,
+          phantomjs_options: [
+            '--load-images=no',
+            '--disk-cache=false',
+            '--ignore-ssl-errors=yes'
+          ],
+          inspector: true
+        )
+      end
+    end
+
   end
 
   describe '#phantomjs' do


### PR DESCRIPTION
https://github.com/DEFRA/quke/issues/64

This change enables users to tell **Quke** whether JavaScript errors in a web page should throw an exception, causing tests to fail.

Based on current research this seems to be an option only available to people using [phantomjs](http://phantomjs.org/) (via [Poltergeist](https://github.com/teampoltergeist/poltergeist). Chrome and Firefox do not appear to provide flags that would cause an exception to be raised, or even an event we could capture and perhaps look to add the functionality into **Quke**.

So this change

- updates the `.config.yml` to add a new flag called `javascript_errors`
- updates `driver_configuration.rb` to make use of this value when setting the **Poltergeist** options