### PR TITLE
More flexibility setting browserstack capabilities

### DIFF
--- a/.config.example.yml
+++ b/.config.example.yml
@@ -96,63 +96,88 @@ proxy:
 # Please see https://www.browserstack.com/automate/capabilities for more details
 browserstack:
   # To run your tests with browserstack you must provide a username and auth_key
-  # as a minimum
+  # as a minimum.
+  # If you don't want to put these credentials in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variables BROWSERSTACK_USERNAME and BROWSERSTACK_AUTH_KEY
   username: jdoe
   auth_key: 123456789ABCDE
 
-  # Keep track of all your automated tests using the build and project
-  # capabilities. Group your tests into builds, and builds further into projects
-  build: 'Version 1'
-  project: 'Adding browserstack support'
+  # Anything set under capabilities will be passed directly by Quke to
+  # browserstack as means of configuring the test.
+  # So the config keys (e.g. build, project, name) you set should match a real
+  # browserstack capability, and the value exist in the range it expects. See
+  # for further reference on browserstack capabilities
+  # https://www.browserstack.com/automate/capabilities
+  # https://www.browserstack.com/automate/ruby#configure-capabilities
+  capabilities:
+    # Keep track of all your automated tests using the build and project
+    # capabilities. Group your tests into builds, and builds further into
+    # projects
+    project: 'Adding browserstack support'
+    build: 'Version 1'
+    # Allows you to specify an identifier for the test run.
+    # If you intend to repeat a test this might not be that applicable, but in
+    # the case of one off tests it might be useful
+    name: 'Testing google search'
 
-  # Allows you to specify an identifier for the test run.
-  # If you intend to repeat a test this might not be that applicable, but in the
-  # case of one off tests it might be useful
-  name: 'Testing google search'
+    # To avoid invalid certificate errors while testing set acceptSslCerts to
+    # true. This is not listed on the general capabilities page but is here
+    # https://www.browserstack.com/automate/ruby#self-signed-certificates
+    acceptSslCerts: true
+    # Required if you want to generate screenshots at various steps in your test
+    # test. Browserstack default is false
+    browserstack.debug: true
+    # Required if you want to enable video recording during your test.
+    # Browserstack default is true
+    browserstack.video: true
+    # Another setting not listed, setting the following will prevent any values
+    # you pass in, for example when filling in a form, from appearing in the
+    # logs. General use case is to prevent passwords being exposed, but beware
+    # that all input will be masked in the logs if set.
+    browserstack.maskSendKeys: true
 
-  # MOBILE testing
-  # The docs are a little confusing but essentially if you want to test against
-  # mobile devices you need to define 1 set of capabilities, and if desktop
-  # another
-  # -----
-  # OS you want to test. Accepted values are MAC, WIN8, XP, WINDOWS, ANY, ANDROID
-  # Browserstack default is ANY
-  platform: MAC
-  # Browser you want to test. Accepted values firefox, chrome, internet explorer,
-  # safari, opera, iPad, iPhone, android. Browserstack default is chrome
-  browserName: iPhone
-  # Browser version you want to test. See the docs for the full list of available
-  # versions. Browserstack default is latest stable version of browser selected
-  version: '49'
-  # Device you want to test on. See the docs for the full list of available.
-  device: 'iPhone 5'
-
-  # DESKTOP testing
-  # -----
-  # OS you want to test. Accepted values are WINDOWS, OS X. If both OS and
-  # platform are set, OS will take precedence
-  os: WINDOWS
-  # OS version you want to test. Accepted values are
-  # Windows: XP, 7, 8, 8.1 and 10
-  # OS X: Snow Leopard, Lion, Mountain Lion, Mavericks, Yosemite, El Capitan
-  os_version: '8.1'
-  # Browser you want to test. Accepted values are Firefox, Safari, IE, Chrome,
-  # Opera
-  browser: chrome
-  # Browser version you want to test. See the docs for the full list of
-  # available versions
-  browser_version: '49'
-  # Set the resolution of VM before beginning of your test.
-  # See docs https://www.browserstack.com/automate/capabilities for full list of
-  # accepted values, as it is also OS dependent
-  resolution: '1024x768'
-
-  # To avoid invalid certificate errors while testing set acceptSslCerts to true
-  acceptSslCerts: true
-
-  # Required if you want to generate screenshots at various steps in your test.
-  # Browserstack default is false
-  debug: true
-  # Required if you want to enable video recording during your test.
-  # Browserstack default is true
-  video: true
+    # MOBILE testing and DESKTOP testing are essentially diametric; you set one
+    # or the other but not both. Some examples seem to put logic in place to
+    # test the options passed in and then set the capabilities accordingly,
+    # however Browserstack handles this and has what will happen documented
+    # https://www.browserstack.com/automate/capabilities#capabilities-parameter-override
+    #
+    # MOBILE testing
+    # The docs are a little confusing but essentially if you want to test against
+    # mobile devices you need to define 1 set of capabilities, and if desktop
+    # another
+    # -----
+    # OS you want to test. Accepted values are MAC, WIN8, XP, WINDOWS, ANY,
+    # ANDROID. Browserstack default is ANY
+    platform: MAC
+    # Browser you want to test. Accepted values firefox, chrome, internet
+    # explorer,safari, opera, iPad, iPhone, android. Browserstack default is
+    # chrome
+    browserName: iPhone
+    # Browser version you want to test. See the docs for the full list of
+    # available versions. Browserstack default is latest stable version of
+    # browser selected
+    version: '49'
+    # Device you want to test on. See the docs for the full list of available.
+    device: 'iPhone 5'
+    #
+    # DESKTOP testing
+    # -----
+    # OS you want to test. Accepted values are WINDOWS, OS X. If both OS and
+    # platform are set, OS will take precedence
+    os: WINDOWS
+    # OS version you want to test. Accepted values are
+    # Windows: XP, 7, 8, 8.1 and 10
+    # OS X: Snow Leopard, Lion, Mountain Lion, Mavericks, Yosemite, El Capitan
+    os_version: '8.1'
+    # Browser you want to test. Accepted values are Firefox, Safari, IE, Chrome,
+    # Opera
+    browser: chrome
+    # Browser version you want to test. See the docs for the full list of
+    # available versions
+    browser_version: '49'
+    # Set the resolution of VM before beginning of your test.
+    # See docs https://www.browserstack.com/automate/capabilities for full list
+    # of accepted values, as it is also OS dependent
+    resolution: '1024x768'

--- a/lib/quke/configuration.rb
+++ b/lib/quke/configuration.rb
@@ -129,7 +129,7 @@ module Quke #:nodoc:
       @data['javascript_errors']
     end
 
-    # Return the hash of +browserstack+ options.
+    # Return the hash of all +browserstack+ options.
     #
     # If you select the browserstack driver, there are a number of options you
     # can pass through to setup your browserstack tests, username and auth_key
@@ -156,7 +156,7 @@ module Quke #:nodoc:
     # It is mainly used when determining whether to apply proxy server settings
     # to the different drivers when registering them with Capybara.
     def use_proxy?
-      proxy['host'] == '' ? false : true
+      proxy['host'] != ''
     end
 
     def custom
@@ -180,6 +180,7 @@ module Quke #:nodoc:
 
     # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/PerceivedComplexity
     def default_data!(data)
       data.merge(
@@ -196,29 +197,27 @@ module Quke #:nodoc:
         # will be 'true', so we flip it back to 'false' with !.
         # Else the condition fails and we get 'false', which when flipped gives
         # us 'true', which is what we want the default value to be
+        # rubocop:disable Style/InverseMethods
         'javascript_errors' => !(data['javascript_errors'].to_s.downcase.strip == 'false'),
+        # rubocop:enable Style/InverseMethods
         'custom' =>            (data['custom'] || nil)
       )
     end
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/PerceivedComplexity
 
-    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/CyclomaticComplexity
     def browserstack_data(data)
       data = {} if data.nil?
       data.merge(
-        'username' => (ENV['BROWSERSTACK_USERNAME'] ||
-                       data['username'] ||
-                       ''
-                      ),
-        'auth_key' => (ENV['BROWSERSTACK_AUTH_KEY'] ||
-                       data['auth_key'] ||
-                       ''
-                      )
+        'username' => (ENV['BROWSERSTACK_USERNAME'] || data['username'] || ''),
+        'auth_key' => (ENV['BROWSERSTACK_AUTH_KEY'] || data['auth_key'] || ''),
+        'capabilities' => data['capabilities'] || {}
       )
     end
-    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     def proxy_data(data)
       data = {} if data.nil?

--- a/lib/quke/driver_configuration.rb
+++ b/lib/quke/driver_configuration.rb
@@ -268,46 +268,20 @@ module Quke #:nodoc:
     # For further reference on browserstack capabilities
     # https://www.browserstack.com/automate/capabilities
     # https://www.browserstack.com/automate/ruby#configure-capabilities
-    # rubocop:disable Metrics/MethodLength
-    # rubocop:disable Metrics/AbcSize
     def browserstack
+      # Documentation and the code for this class can be found here
+      # http://www.rubydoc.info/gems/selenium-webdriver/0.0.28/Selenium/WebDriver/Remote/Capabilities
+      # https://github.com/SeleniumHQ/selenium/blob/master/rb/lib/selenium/webdriver/remote/capabilities.rb
       capabilities = Selenium::WebDriver::Remote::Capabilities.new
 
-      capabilities['build'] = config.browserstack['build']
-      capabilities['project'] = config.browserstack['project']
-      capabilities['name'] = config.browserstack['name']
+      browserstack_capabilities = config.browserstack['capabilities']
 
-      # This and the following section are essentially diametric; you set one
-      # or the other but not both. Some examples seem to put logic in place to
-      # test the options passed in and then set the capabilities accordingly,
-      # however Browserstack handles this and has what will happen documented
-      # https://www.browserstack.com/automate/capabilities#capabilities-parameter-override
-      capabilities['platform'] = config.browserstack['platform']
-      capabilities['browserName'] = config.browserstack['browserName']
-      capabilities['version'] = config.browserstack['version']
-      capabilities['device'] = config.browserstack['device']
+      browserstack_capabilities.each do |key, value|
+        capabilities[key] = value
+      end
 
-      capabilities['os'] = config.browserstack['os']
-      capabilities['os_version'] = config.browserstack['os_version']
-      capabilities['browser'] = config.browserstack['browser']
-      capabilities['browser_version'] = config.browserstack['browser_version']
-      capabilities['resolution'] = config.browserstack['resolution']
-      # -----
-
-      # This is not listed on the general capabilities page but is here
-      # https://www.browserstack.com/automate/ruby#self-signed-certificates
-      capabilities['acceptSslCerts'] = config.browserstack['acceptSslCerts']
-
-      capabilities['browserstack.debug'] = config.browserstack['debug']
-      capabilities['browserstack.video'] = config.browserstack['video']
-
-      # At this point Quke does not support local testing so we specifically
-      # tell Browserstack we're not doing this
-      capabilities['browserstack.local'] = 'false'
       capabilities
     end
-    # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/MethodLength
 
   end
 

--- a/lib/quke/version.rb
+++ b/lib/quke/version.rb
@@ -1,3 +1,3 @@
 module Quke #:nodoc:
-  VERSION = '0.3.2'.freeze
+  VERSION = '0.4.0'.freeze
 end

--- a/spec/data/.browserstack.yml
+++ b/spec/data/.browserstack.yml
@@ -7,24 +7,26 @@ browserstack:
   username: jdoe
   auth_key: 123456789ABCDE
 
-  build: 'Version 1'
-  project: 'Adding browserstack support'
+  capabilities:
+    build: 'Version 1'
+    project: 'Adding browserstack support'
+    name: 'Testing google search'
 
-  name: 'Testing google search'
+    acceptSslCerts: true
+    browserstack.debug: true
+    browserstack.video: true
+    browserstack.local: true
+    browserstack.maskSendKeys: true
 
-  # MOBILE testing
-  platform: MAC
-  browserName: iPhone
-  version: '49'
-  device: 'iPhone 5'
+    # MOBILE testing
+    platform: MAC
+    browserName: iPhone
+    version: '49'
+    device: 'iPhone 5'
 
-  # DESKTOP testing
-  os: WINDOWS
-  os_version: '8.1'
-  browser: chrome
-  browser_version: '49'
-  resolution: '1024x768'
-
-  acceptSslCerts: true
-  debug: true
-  video: true
+    # DESKTOP testing
+    os: WINDOWS
+    os_version: '8.1'
+    browser: chrome
+    browser_version: '49'
+    resolution: '1024x768'

--- a/spec/data/.simple.yml
+++ b/spec/data/.simple.yml
@@ -11,5 +11,6 @@ max_wait_time: 3
 browserstack:
   username: jdoe
   auth_key: 123456789ABCDE
-  build: 'Version 1'
-  project: 'Adding browserstack support'
+  capabilities:
+    build: 'Version 1'
+    project: 'Adding browserstack support'

--- a/spec/quke/configuration_spec.rb
+++ b/spec/quke/configuration_spec.rb
@@ -206,21 +206,22 @@ RSpec.describe Quke::Configuration do
 
   describe '#browserstack' do
     context 'when NOT specified in the config file' do
-      it 'defaults to a blank username and auth_key' do
+      it 'defaults to a blank username, auth_key and empty capabilities hash' do
         Quke::Configuration.file_location = data_path('.no_file.yml')
-        expect(subject.browserstack).to eq('username' => '', 'auth_key' => '')
+        expect(subject.browserstack).to eq(
+          'username' => '',
+          'auth_key' => '',
+          'capabilities' => {}
+        )
       end
     end
 
     context 'when specified in the config file' do
       it 'matches the config file' do
         Quke::Configuration.file_location = data_path('.simple.yml')
-        expect(subject.browserstack).to eq(
-          'username' => 'jdoe',
-          'auth_key' => '123456789ABCDE',
-          'build' => 'Version 1',
-          'project' => 'Adding browserstack support'
-        )
+        expected_config = YAML.load_file(data_path('.simple.yml'))['browserstack']
+
+        expect(subject.browserstack).to eq(expected_config)
       end
     end
   end
@@ -283,9 +284,8 @@ RSpec.describe Quke::Configuration do
     it 'return the values held by the instance and not an instance ID' do
       Quke::Configuration.file_location = data_path('.no_file.yml')
       # rubocop:disable Style/StringLiterals
-      puts subject.to_s
       expect(subject.to_s).to eq(
-        "{\"features_folder\"=>\"features\", \"app_host\"=>\"\", \"driver\"=>\"phantomjs\", \"pause\"=>0, \"stop_on_error\"=>\"false\", \"max_wait_time\"=>2, \"user_agent\"=>\"\", \"javascript_errors\"=>true, \"custom\"=>nil, \"browserstack\"=>{\"username\"=>\"\", \"auth_key\"=>\"\"}, \"proxy\"=>{\"host\"=>\"\", \"port\"=>0, \"no_proxy\"=>\"\"}}"
+        "{\"features_folder\"=>\"features\", \"app_host\"=>\"\", \"driver\"=>\"phantomjs\", \"pause\"=>0, \"stop_on_error\"=>\"false\", \"max_wait_time\"=>2, \"user_agent\"=>\"\", \"javascript_errors\"=>true, \"custom\"=>nil, \"browserstack\"=>{\"username\"=>\"\", \"auth_key\"=>\"\", \"capabilities\"=>{}}, \"proxy\"=>{\"host\"=>\"\", \"port\"=>0, \"no_proxy\"=>\"\"}}"
       )
       # rubocop:enable Style/StringLiterals
     end

--- a/spec/quke/driver_configuration_spec.rb
+++ b/spec/quke/driver_configuration_spec.rb
@@ -248,27 +248,20 @@ RSpec.describe Quke::DriverConfiguration do
   describe '#browserstack' do
 
     context 'browserstack details have NOT been set in the .config.yml' do
-      it 'returns capabilities set to the browserstack defaults' do
+      it 'returns capabilities set to Selenium::WebDriver::Remote::Capabilities defaults' do
         Quke::Configuration.file_location = data_path('.no_file.yml')
         config = Quke::Configuration.new
         capabilities = Quke::DriverConfiguration.new(config).browserstack
 
-        expect(capabilities['build']).to eq(nil)
-        expect(capabilities['project']).to eq(nil)
-        expect(capabilities['name']).to eq(nil)
-        expect(capabilities['platform']).to eq(nil)
+        expect(capabilities.as_json.keys.count).to eq(8)
         expect(capabilities['browserName']).to eq(nil)
         expect(capabilities['version']).to eq(nil)
-        expect(capabilities['device']).to eq(nil)
-        expect(capabilities['os']).to eq(nil)
-        expect(capabilities['os_version']).to eq(nil)
-        expect(capabilities['browser']).to eq(nil)
-        expect(capabilities['browser_version']).to eq(nil)
-        expect(capabilities['resolution']).to eq(nil)
-        expect(capabilities['acceptSslCerts']).to eq(nil)
-        expect(capabilities['browserstack.debug']).to eq(nil)
-        expect(capabilities['browserstack.video']).to eq(nil)
-        expect(capabilities['browserstack.local']).to eq('false')
+        expect(capabilities['platform']).to eq(nil)
+        expect(capabilities['javascriptEnabled']).to eq(nil)
+        expect(capabilities['cssSelectorsEnabled']).to eq(nil)
+        expect(capabilities['takesScreenshot']).to eq(nil)
+        expect(capabilities['nativeEvents']).to eq(nil)
+        expect(capabilities['rotatable']).to eq(nil)
       end
     end
 
@@ -277,23 +270,27 @@ RSpec.describe Quke::DriverConfiguration do
         Quke::Configuration.file_location = data_path('.browserstack.yml')
         config = Quke::Configuration.new
         capabilities = Quke::DriverConfiguration.new(config).browserstack
+        expected_capabilities = YAML.load_file(data_path('.browserstack.yml'))['browserstack']['capabilities']
 
-        expect(capabilities['build']).to eq('Version 1')
-        expect(capabilities['project']).to eq('Adding browserstack support')
-        expect(capabilities['name']).to eq('Testing google search')
-        expect(capabilities['platform']).to eq('MAC')
-        expect(capabilities['browserName']).to eq('iPhone')
-        expect(capabilities['version']).to eq('49')
-        expect(capabilities['device']).to eq('iPhone 5')
-        expect(capabilities['os']).to eq('WINDOWS')
-        expect(capabilities['os_version']).to eq('8.1')
-        expect(capabilities['browser']).to eq('chrome')
-        expect(capabilities['browser_version']).to eq('49')
-        expect(capabilities['resolution']).to eq('1024x768')
-        expect(capabilities['acceptSslCerts']).to eq(true)
-        expect(capabilities['browserstack.debug']).to eq(true)
-        expect(capabilities['browserstack.video']).to eq(true)
-        expect(capabilities['browserstack.local']).to eq('false')
+        expect(capabilities['build']).to eq(expected_capabilities['build'])
+        expect(capabilities['project']).to eq(expected_capabilities['project'])
+        expect(capabilities['name']).to eq(expected_capabilities['name'])
+
+        expect(capabilities['acceptSslCerts']).to eq(expected_capabilities['acceptSslCerts'])
+        expect(capabilities['browserstack.debug']).to eq(expected_capabilities['browserstack.debug'])
+        expect(capabilities['browserstack.video']).to eq(expected_capabilities['browserstack.video'])
+        expect(capabilities['browserstack.local']).to eq(expected_capabilities['browserstack.local'])
+        expect(capabilities['browserstack.maskSendKeys']).to eq(expected_capabilities['browserstack.maskSendKeys'])
+
+        expect(capabilities['platform']).to eq(expected_capabilities['platform'])
+        expect(capabilities['browserName']).to eq(expected_capabilities['browserName'])
+        expect(capabilities['version']).to eq(expected_capabilities['version'])
+        expect(capabilities['device']).to eq(expected_capabilities['device'])
+        expect(capabilities['os']).to eq(expected_capabilities['os'])
+        expect(capabilities['os_version']).to eq(expected_capabilities['os_version'])
+        expect(capabilities['browser']).to eq(expected_capabilities['browser'])
+        expect(capabilities['browser_version']).to eq(expected_capabilities['browser_version'])
+        expect(capabilities['resolution']).to eq(expected_capabilities['resolution'])
       end
     end
 


### PR DESCRIPTION
Prior to this change **Quke** looked for specific values in the `.config.yml` file and then set those as capabilities in the Browserstack driver. However we've had a coup0le of requests for specific things to be passed through. Continuing to support Browserstack in this way would mean continually having to dive back into the code and adding support for each and every flag.

So instead this updates **Quke** to be more flexible. Now it will simply pass in the values set in `.config.yml` (under browserstack) to the `Selenium::WebDriver::Remote::Capabilities` object we create, using the keys in the config as the names of the keys in the capabilities.

Essentially we're moving to an assumption that the user knows what they are doing when it come to Browserstack. So we'll handle setting up the driver and **Quke**, but get out of their way when it comes to browserstack.

It should be noted this is a breaking change for Browserstack users. Both the username and auth_key, and the capabilities to be set for the test used to be found directly under the node `browserstack:`. Now Quke will expect them to be placed under `browserstack: capabilities:` for example

```yaml
browserstack:
  username: jdoe
  auth_key: 123456789ABCDE
  capabilities:
    project: 'Adding browserstack support'
    build: 'Version 1'
```