### PR TITLE
Add support for browserstack local testing

### DIFF
--- a/.config.example.yml
+++ b/.config.example.yml
@@ -103,6 +103,11 @@ browserstack:
   username: jdoe
   auth_key: 123456789ABCDE
 
+  # If you want to use local testing you must provide a key. You can find this
+  # in Browserstack once logged in under settings. Its typically the same value
+  # as the auth_key above
+  local_key: 123456789ABCDE
+
   # Anything set under capabilities will be passed directly by Quke to
   # browserstack as means of configuring the test.
   # So the config keys (e.g. build, project, name) you set should match a real
@@ -131,6 +136,13 @@ browserstack:
     # Required if you want to enable video recording during your test.
     # Browserstack default is true
     browserstack.video: true
+    # Required if you need to test a locally hosted (e.g. http://localhost:300)
+    # or private internal web site. Browserstack has a feature called local
+    # testing that Quke also supports, but to use
+    # - Browserstack must be your selected driver
+    # - You must have set local_key above
+    # - You must this value to true
+    browserstack.local: false
     # Another setting not listed, setting the following will prevent any values
     # you pass in, for example when filling in a form, from appearing in the
     # logs. General use case is to prevent passwords being exposed, but beware

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,20 +21,30 @@ AllCops:
   # investigating what the fix may be.
   DisplayStyleGuide: true
 
-# Disable this rubocop style because we want to make the arguments passed into
-# Freakin available to anywhere when the code is executed
-Style/GlobalVars:
-  Enabled: false
-
 # It is our opinion that code is easier to read if a white space is
 # permitted between the initial declaration and the first statement. Ditto the
 # last statement and the closing tag.
-Style/EmptyLinesAroundModuleBody:
+Layout/EmptyLinesAroundModuleBody:
   Enabled: false
-Style/EmptyLinesAroundClassBody:
+Layout/EmptyLinesAroundClassBody:
   Enabled: false
-Style/EmptyLinesAroundBlockBody:
+Layout/EmptyLinesAroundBlockBody:
     Enabled: false
+
+# Rubocop appears to flag `describe` blocks which are longer than 25 lines.
+# However it is our opinion that this is necessary in specs, for example when
+# describing a class, the body of the describe may well exceed 25 lines.
+# Therefore we have excluded this rule in the specs only.
+Metrics/BlockLength:
+  Exclude:
+    - spec/quke/*.rb
+
+# We wish we were good enough to remain within the rubocop limit of 10 lines
+# however we often just seem to tip over by a few lines. Hence we have chosen
+# to bump it to 15.
+Metrics/MethodLength:
+  Max: 15
+  Exclude:
 
 # It is our opinion that in the specs 80 characters is too restrictive. Do to
 # the nature of some statements that it can be both difficult, and make more
@@ -45,10 +55,7 @@ Metrics/LineLength:
   Exclude:
     - spec/quke/*.rb
 
-# Rubocop appears to flag `describe` blocks which are longer than 25 lines.
-# However it is our opinion that this is necessary in specs, for example when
-# describing a class, the body of the describe may well exceed 25 lines.
-# Therefore we have excluded this rule in the specs only.
-Metrics/BlockLength:
-  Exclude:
-    - spec/quke/*.rb
+# Disable this rubocop style because we want to make the arguments passed into
+# Freakin available to anywhere when the code is executed
+Style/GlobalVars:
+  Enabled: false

--- a/lib/quke.rb
+++ b/lib/quke.rb
@@ -1,4 +1,5 @@
 require 'quke/version'
+require 'quke/browserstack_configuration'
 require 'quke/configuration'
 require 'quke/cuke_runner'
 require 'quke/driver_registration'

--- a/lib/quke/browserstack_configuration.rb
+++ b/lib/quke/browserstack_configuration.rb
@@ -1,0 +1,138 @@
+module Quke #:nodoc:
+
+  # Determines the configuration for browserstack, when selected as the driver
+  class BrowserstackConfiguration
+    # To run your tests with browserstack you must provide a username and
+    # auth_key as a minimum.
+    #
+    # If the user doesn't put these credentials in the config file (because they
+    # don't want to commit them to source control), Quke will also check for the
+    # existance of the environment variables BROWSERSTACK_USERNAME and
+    # BROWSERSTACK_AUTH_KEY and use them instead
+    attr_reader :username, :auth_key
+
+    # To use local testing users must provide a key. They will find this in
+    # Browserstack once logged in under settings. Its typically the same value
+    # as the auth_key above
+    attr_reader :local_key
+
+    # Capabilities are what configure the test in browserstack, for example
+    # what OS and browser to use.
+    #
+    # Further reference on browserstack capabilities
+    # https://www.browserstack.com/automate/capabilities
+    # https://www.browserstack.com/automate/ruby#configure-capabilities
+    attr_reader :capabilities
+
+    # Returns a hash of configurations values that will be passed to the
+    # +browserstack+ local binary when its started.
+    #
+    # The project uses the gem +browserstack-local+ to manage starting and
+    # stopping the binary Browserstack provide for local testing. When started
+    # you can configure how it behaviours by passing in a set of arguments as a
+    # hash. This method generates the hash based on a mix of default values and
+    # ones taken from the +.config.yml+.
+    #
+    # See https://github.com/browserstack/browserstack-local-ruby#arguments
+    # https://www.browserstack.com/local-testing
+    attr_reader :local_testing_args
+
+    # Initialize's the instance based in the +Quke::Configuration+ instance
+    # passed in.
+    #
+    # rubocop:disable Metrics/CyclomaticComplexity
+    def initialize(configuration)
+      @using_browserstack = configuration.data['driver'] == 'browserstack'
+      data = validate_input_data(configuration.data)
+      @username = ENV['BROWSERSTACK_USERNAME'] || data['username'] || ''
+      @auth_key = ENV['BROWSERSTACK_AUTH_KEY'] || data['auth_key'] || ''
+      @local_key = data['local_key'] || ''
+      @capabilities = data['capabilities'] || {}
+      determine_local_testing_args(configuration)
+    end
+    # rubocop:enable Metrics/CyclomaticComplexity
+
+    # Return true if the +browserstack.local: true+ value has been set in the
+    # +.config.yml+ file and the driver is set to 'browserstack', else false.
+    #
+    # It is used when determing whether to start and stop the binary
+    # Browserstack provides to support local testing.
+    def test_locally?
+      @capabilities['browserstack.local'] == true && using_browserstack?
+    end
+
+    # Returns true if the driver was set +browserstack+, else false.
+    #
+    # This class needs to know whether browserstack was selected as the driver
+    # to use in order to correctly determine is the browserstack local testing
+    # binary needs to be stopped and started for the tests.
+    #
+    # However it also serves as a clean and simple way ton determine if
+    # browserstack is the selected dribver.
+    def using_browserstack?
+      @using_browserstack
+    end
+
+    # Returns a string representing the url used when running tests via
+    # Browserstack[https://www.browserstack.com/] or nil.
+    #
+    # It will contain the username and auth_key set in the +.config.yml+, else
+    # if +username+ is blank it will return nil.
+    #
+    # An example return value
+    #
+    #     "http://jdoe:123456789ABCDE@hub.browserstack.com/wd/hub"
+    #
+    # It is used when registering the driver with Capybara. So instead of this
+    #
+    #     Capybara::Selenium::Driver.new(
+    #       app,
+    #       browser: :remote,
+    #       url: 'http://jdoe:123456789ABCDE@hub.browserstack.com/wd/hub',
+    #       desired_capabilities: my_capabilites
+    #     )
+    #
+    # You can call +browserstack_url+ to get the url to use
+    #
+    #     Capybara::Selenium::Driver.new(
+    #       app,
+    #       browser: :remote,
+    #       url: my_config.browserstack_config.url,
+    #       desired_capabilities: my_capabilites
+    #     )
+    #
+    def url
+      return "http://#{@username}:#{@auth_key}@hub.browserstack.com/wd/hub" unless @username == ''
+    end
+
+    private
+
+    def validate_input_data(data)
+      return {} if data.nil?
+      return {} unless data['browserstack']
+      data['browserstack']
+    end
+
+    def determine_local_testing_args(configuration)
+      @local_testing_args = {
+        # Key is the only required arg. Everything else is optional
+        'key' => @local_key,
+        # Always kill other running Browserstack Local instances
+        'force' => 'true',
+        # We only want to enable local testing for automate
+        'onlyAutomate' => 'true',
+        # Enable verbose logging. It's of no consequence to the tests, but it
+        # could help in the event of errors
+        'v' => 'true',
+        # Rather than
+        'logfile' => File.join(Dir.pwd, '/tmp/bowerstack_local_log.txt')
+      }
+      return unless configuration.use_proxy?
+
+      @local_testing_args['proxyHost'] = configuration.proxy['host']
+      @local_testing_args['proxyPort'] = configuration.proxy['port'].to_s
+    end
+
+  end
+
+end

--- a/lib/quke/configuration.rb
+++ b/lib/quke/configuration.rb
@@ -9,8 +9,12 @@ module Quke #:nodoc:
     # Quke::Configuration.
     attr_reader :file_location
 
-    # Access the loaded config data object directly
+    # Access the loaded config data object directly.
     attr_reader :data
+
+    # Instance of +Quke::BrowserstackConfiguration+ which manages reading and
+    # returning the config for setting up Quke to use browserstack.
+    attr_reader :browserstack
 
     class << self
       # Class level setter for the location of the config file.
@@ -38,6 +42,7 @@ module Quke #:nodoc:
     # calling a private method +load_data()+.
     def initialize
       @data = load_data
+      @browserstack = ::Quke::BrowserstackConfiguration.new(self)
     end
 
     # Returns the value set for +features_folder+.
@@ -129,18 +134,6 @@ module Quke #:nodoc:
       @data['javascript_errors']
     end
 
-    # Return the hash of all +browserstack+ options.
-    #
-    # If you select the browserstack driver, there are a number of options you
-    # can pass through to setup your browserstack tests, username and auth_key
-    # being the critical ones.
-    #
-    # Please see https://www.browserstack.com/automate/capabilities for more
-    # details.
-    def browserstack
-      @data['browserstack']
-    end
-
     # Return the hash of +proxy+ server settings
     #
     # If your environment requires you to go via a proxy server you can
@@ -163,24 +156,16 @@ module Quke #:nodoc:
       @data['custom']
     end
 
-    # Override to_s to output the contents of Config as a readable string rather
-    # than the standard object output you get.
-    def to_s
-      @data.to_s
-    end
-
     private
 
     def load_data
       data = default_data!(load_yml_data)
-      data['browserstack'] = browserstack_data(data['browserstack'])
       data['proxy'] = proxy_data(data['proxy'])
       data
     end
 
     # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/PerceivedComplexity
     def default_data!(data)
       data.merge(
@@ -205,19 +190,7 @@ module Quke #:nodoc:
     end
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/CyclomaticComplexity
-    # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/PerceivedComplexity
-
-    # rubocop:disable Metrics/CyclomaticComplexity
-    def browserstack_data(data)
-      data = {} if data.nil?
-      data.merge(
-        'username' => (ENV['BROWSERSTACK_USERNAME'] || data['username'] || ''),
-        'auth_key' => (ENV['BROWSERSTACK_AUTH_KEY'] || data['auth_key'] || ''),
-        'capabilities' => data['capabilities'] || {}
-      )
-    end
-    # rubocop:enable Metrics/CyclomaticComplexity
 
     def proxy_data(data)
       data = {} if data.nil?

--- a/lib/quke/driver_configuration.rb
+++ b/lib/quke/driver_configuration.rb
@@ -202,40 +202,6 @@ module Quke #:nodoc:
     end
     # rubocop:enable Metrics/AbcSize
 
-    # Returns a string representing the url used when running tests via
-    # Browserstack[https://www.browserstack.com/] or nil.
-    #
-    # It will contain the username and auth_key set in the +.config.yml+, else
-    # if +username+ is blank it will return nil.
-    #
-    # An example return value
-    #
-    #     "http://jdoe:123456789ABCDE@hub.browserstack.com/wd/hub"
-    #
-    # It is used when registering the driver with Capybara. So instead of this
-    #
-    #     Capybara::Selenium::Driver.new(
-    #       app,
-    #       browser: :remote,
-    #       url: 'http://jdoe:123456789ABCDE@hub.browserstack.com/wd/hub',
-    #       desired_capabilities: my_capabilites
-    #     )
-    #
-    # You can call +browserstack_url+ to get the url to use
-    #
-    #     Capybara::Selenium::Driver.new(
-    #       app,
-    #       browser: :remote,
-    #       url: my_driver_config.browserstack_url,
-    #       desired_capabilities: my_capabilites
-    #     )
-    #
-    def browserstack_url
-      username = config.browserstack['username']
-      key = config.browserstack['auth_key']
-      return "http://#{username}:#{key}@hub.browserstack.com/wd/hub" unless username == ''
-    end
-
     # Returns an instance of Selenium::WebDriver::Remote::Capabilities to be
     # used when registering an instance of Capybara::Selenium::Driver,
     # configured to run using the Browserstack[https://www.browserstack.com/]
@@ -274,9 +240,7 @@ module Quke #:nodoc:
       # https://github.com/SeleniumHQ/selenium/blob/master/rb/lib/selenium/webdriver/remote/capabilities.rb
       capabilities = Selenium::WebDriver::Remote::Capabilities.new
 
-      browserstack_capabilities = config.browserstack['capabilities']
-
-      browserstack_capabilities.each do |key, value|
+      config.browserstack.capabilities.each do |key, value|
         capabilities[key] = value
       end
 

--- a/lib/quke/driver_registration.rb
+++ b/lib/quke/driver_registration.rb
@@ -10,13 +10,19 @@ module Quke #:nodoc:
 
     # Access the instance of Quke::DriverConfiguration passed to this instance
     # of Quke::DriverRegistration when it was initialized.
+    attr_reader :driver_config
+
+    # Access the instance of Quke::Configuration passed to this instance of
+    # Quke::DriverOptions when it was initialized.
     attr_reader :config
 
     # Instantiate an instance of Quke::DriverRegistration.
     #
     # It expects an instance of Quke::DriverConfiguration which will detail the
-    # driver to be used and any related options
-    def initialize(config)
+    # driver to be used and any related options, and Quke::Configuration
+    # specifically for access to the browserstack config.
+    def initialize(driver_config, config)
+      @driver_config = driver_config
       @config = config
     end
 
@@ -56,7 +62,7 @@ module Quke #:nodoc:
         # called, all we're doing here is telling it what block (code) to
         # execute at that time.
         # :simplecov_ignore:
-        Capybara::Poltergeist::Driver.new(app, config.poltergeist)
+        Capybara::Poltergeist::Driver.new(app, @driver_config.poltergeist)
         # :simplecov_ignore:
       end
       :phantomjs
@@ -74,7 +80,7 @@ module Quke #:nodoc:
       # http://preferential.mozdev.org/preferences.html
       Capybara.register_driver :firefox do |app|
         # :simplecov_ignore:
-        Capybara::Selenium::Driver.new(app, profile: config.firefox)
+        Capybara::Selenium::Driver.new(app, profile: @driver_config.firefox)
         # :simplecov_ignore:
       end
       :firefox
@@ -94,7 +100,7 @@ module Quke #:nodoc:
         Capybara::Selenium::Driver.new(
           app,
           browser: :chrome,
-          switches: config.chrome
+          switches: @driver_config.chrome
         )
         # :simplecov_ignore:
       end
@@ -111,8 +117,8 @@ module Quke #:nodoc:
         Capybara::Selenium::Driver.new(
           app,
           browser: :remote,
-          url: config.browserstack_url,
-          desired_capabilities: config.browserstack
+          url: @config.browserstack.url,
+          desired_capabilities: @driver_config.browserstack
         )
         # :simplecov_ignore:
       end

--- a/lib/quke/version.rb
+++ b/lib/quke/version.rb
@@ -1,3 +1,3 @@
 module Quke #:nodoc:
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.5.0'.freeze
 end

--- a/quke.gemspec
+++ b/quke.gemspec
@@ -1,4 +1,3 @@
-# coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'quke/version'
@@ -90,12 +89,17 @@ Gem::Specification.new do |spec|
   # will instead open in the default browser instead.
   spec.add_dependency 'launchy', '~> 2.4'
 
+  # Ruby bindings for BrowserStack Local. This gem handles downloading and
+  # installing the right version of the binary for the OS Quke is running on,
+  # and provides an API for managing it.
+  spec.add_dependency 'browserstack-local'
+
   spec.add_development_dependency 'bundler', '~> 1.12'
+  spec.add_development_dependency 'codeclimate-test-reporter', '~> 0.6'
+  spec.add_development_dependency 'github_changelog_generator', '~> 1.13'
   spec.add_development_dependency 'rake', '~> 10.5'
   spec.add_development_dependency 'rdoc', '~> 4.2'
   spec.add_development_dependency 'rspec', '~> 3.5'
-  spec.add_development_dependency 'codeclimate-test-reporter', '~> 0.6'
   spec.add_development_dependency 'simplecov', '~> 0.12'
-  spec.add_development_dependency 'github_changelog_generator', '~> 1.13'
 end
 # rubocop:enable Metrics/BlockLength

--- a/spec/data/.as_string.yml
+++ b/spec/data/.as_string.yml
@@ -8,3 +8,7 @@ javascript_errors: 'false'
 
 proxy:
   port: '8080'
+
+browserstack:
+  capabilities:
+    browserstack.local: 'true'

--- a/spec/data/.browserstack.yml
+++ b/spec/data/.browserstack.yml
@@ -1,11 +1,14 @@
 features: 'spec'
 driver: browserstack
 
+proxy:
+  host: '10.10.2.70'
+  port: 8080
+
 browserstack:
-  # To run your tests with browserstack you must provide a username and auth_key
-  # as a minimum
   username: jdoe
   auth_key: 123456789ABCDE
+  local_key: 123456789ABCDE
 
   capabilities:
     build: 'Version 1'

--- a/spec/data/.simple.yml
+++ b/spec/data/.simple.yml
@@ -11,6 +11,8 @@ max_wait_time: 3
 browserstack:
   username: jdoe
   auth_key: 123456789ABCDE
+  local_key: 123456789ABCDE
   capabilities:
     build: 'Version 1'
     project: 'Adding browserstack support'
+    browserstack.local: true

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -30,7 +30,7 @@ module Helpers
   # this appears to be the case for most of its properties.
   # https://github.com/SeleniumHQ/selenium/blob/master/rb/lib/selenium/webdriver/firefox/profile.rb
   #
-  # However having checked how they have written there tests for this class
+  # However having checked how they have written their tests for this class
   # (https://github.com/SeleniumHQ/selenium/blob/master/rb/spec/integration/selenium/webdriver/firefox/profile_spec.rb)
   # we were able to find Selenium::WebDriver::Firefox::Profile has a method
   # called +layout_on_disk+ which writes the profile to files. The Selenium team

--- a/spec/quke/browserstack_configuration_spec.rb
+++ b/spec/quke/browserstack_configuration_spec.rb
@@ -1,0 +1,232 @@
+require 'spec_helper'
+
+RSpec.describe Quke::BrowserstackConfiguration do
+  describe 'instantiating' do
+    context 'when `.config.yml` is blank or contains no browserstack section' do
+      let(:config) do
+        Quke::Configuration.file_location = data_path('.no_file.yml')
+        Quke::Configuration.new
+      end
+      subject { Quke::BrowserstackConfiguration.new(config) }
+
+      it 'returns an instance defaulted to blank values' do
+        expect(subject.username).to eq('')
+        expect(subject.auth_key).to eq('')
+        expect(subject.local_key).to eq('')
+        expect(subject.capabilities).to eq({})
+      end
+
+    end
+
+    context 'when `.config.yml` contains a browserstack section' do
+      let(:config) do
+        Quke::Configuration.file_location = data_path('.simple.yml')
+        Quke::Configuration.new
+      end
+      subject { Quke::BrowserstackConfiguration.new(config) }
+
+      it 'returns an instance with properties that match the input' do
+        expect(subject.username).to eq('jdoe')
+        expect(subject.auth_key).to eq('123456789ABCDE')
+        expect(subject.local_key).to eq('123456789ABCDE')
+        expect(subject.capabilities).to eq(
+          'build' => 'Version 1',
+          'project' => 'Adding browserstack support',
+          'browserstack.local' => true
+        )
+      end
+
+    end
+  end
+
+  describe '#test_locally?' do
+    context 'when `.config.yml` is blank or contains no browserstack section' do
+      let(:config) do
+        Quke::Configuration.file_location = data_path('.no_file.yml')
+        Quke::Configuration.new
+      end
+      subject { Quke::BrowserstackConfiguration.new(config) }
+
+      it 'returns false' do
+        expect(subject.test_locally?).to eq(false)
+      end
+
+    end
+
+    context "when the driver is not set to 'browserstack' in `.config.yml`" do
+      let(:config) do
+        Quke::Configuration.file_location = data_path('.simple.yml')
+        Quke::Configuration.new
+      end
+      subject { Quke::BrowserstackConfiguration.new(config) }
+
+      it 'returns false' do
+        expect(subject.test_locally?).to eq(false)
+      end
+
+    end
+
+    # Unlike some aspects of Quke's configuration where we handle users mixing
+    # strings and booleans ('true' and true) for setting values, because the
+    # browserstack capabilities are passed straight through we return false
+    # in this scenario to reflect what browserstack's behaviour would be
+    # i.e. it would fail to recognise that running locally is needed.
+    context "when the driver is 'browserstack' and use local testing is set to 'true' (a string) in `.config.yml`" do
+      let(:config) do
+        Quke::Configuration.file_location = data_path('.as_string.yml')
+        Quke::Configuration.new
+      end
+      subject { Quke::BrowserstackConfiguration.new(config) }
+
+      it 'returns false' do
+        expect(subject.test_locally?).to eq(false)
+      end
+
+    end
+
+    context "when the driver is 'browserstack' and use local testing is set to true in `.config.yml`" do
+      let(:config) do
+        Quke::Configuration.file_location = data_path('.browserstack.yml')
+        Quke::Configuration.new
+      end
+      subject { Quke::BrowserstackConfiguration.new(config) }
+
+      it 'returns true' do
+        expect(subject.test_locally?).to eq(true)
+      end
+
+    end
+  end
+
+  describe 'local_testing_args' do
+    context 'when `.config.yml` is blank or contains no browserstack section' do
+      let(:config) do
+        Quke::Configuration.file_location = data_path('.no_file.yml')
+        Quke::Configuration.new
+      end
+      subject { Quke::BrowserstackConfiguration.new(config) }
+
+      it 'defaults to a blank key, and our standard args for the local binary' do
+        expect(subject.local_testing_args).to eq(
+          'key' => '',
+          'force' => 'true',
+          'onlyAutomate' => 'true',
+          'v' => 'true',
+          'logfile' => File.join(Dir.pwd, '/tmp/bowerstack_local_log.txt')
+        )
+      end
+
+    end
+
+    context 'when `.config.yml` contains just proxy details' do
+      let(:config) do
+        Quke::Configuration.file_location = data_path('.proxy_basic.yml')
+        Quke::Configuration.new
+      end
+      subject { Quke::BrowserstackConfiguration.new(config) }
+
+      it 'defaults to a blank key, our standard args for the local binary, plus the proxy values' do
+        expect(subject.local_testing_args).to eq(
+          'key' => '',
+          'force' => 'true',
+          'onlyAutomate' => 'true',
+          'v' => 'true',
+          'logfile' => File.join(Dir.pwd, '/tmp/bowerstack_local_log.txt'),
+          'proxyHost' => '10.10.2.70',
+          'proxyPort' => '8080'
+        )
+      end
+    end
+
+    context 'when `.config.yml` contains both browserstack and proxy details' do
+      let(:config) do
+        Quke::Configuration.file_location = data_path('.browserstack.yml')
+        Quke::Configuration.new
+      end
+      subject { Quke::BrowserstackConfiguration.new(config) }
+
+      it 'defaults to a blank key, our standard args for the local binary, plus the proxy values' do
+        expect(subject.local_testing_args).to eq(
+          'key' => '123456789ABCDE',
+          'force' => 'true',
+          'onlyAutomate' => 'true',
+          'v' => 'true',
+          'logfile' => File.join(Dir.pwd, '/tmp/bowerstack_local_log.txt'),
+          'proxyHost' => '10.10.2.70',
+          'proxyPort' => '8080'
+        )
+      end
+
+    end
+  end
+
+  describe '#using_browserstack?' do
+    context 'when `.config.yml` is blank' do
+      let(:config) do
+        Quke::Configuration.file_location = data_path('.no_file.yml')
+        Quke::Configuration.new
+      end
+      subject { Quke::BrowserstackConfiguration.new(config) }
+
+      it 'returns false' do
+        expect(subject.using_browserstack?).to eq(false)
+      end
+
+    end
+
+    context "when `.config.yml` DOES NOT specify 'browserstack' as the driver" do
+      let(:config) do
+        Quke::Configuration.file_location = data_path('.simple.yml')
+        Quke::Configuration.new
+      end
+      subject { Quke::BrowserstackConfiguration.new(config) }
+
+      it 'returns false' do
+        expect(subject.using_browserstack?).to eq(false)
+      end
+    end
+
+    context "when `.config.yml` specifies 'browserstack' as the driver" do
+      let(:config) do
+        Quke::Configuration.file_location = data_path('.browserstack.yml')
+        Quke::Configuration.new
+      end
+      subject { Quke::BrowserstackConfiguration.new(config) }
+
+      it 'returns true' do
+        expect(subject.using_browserstack?).to eq(true)
+      end
+
+    end
+  end
+
+  describe '#url' do
+
+    context 'when `.config.yml` is blank or contains no browserstack section' do
+      let(:config) do
+        Quke::Configuration.file_location = data_path('.no_file.yml')
+        Quke::Configuration.new
+      end
+      subject { Quke::BrowserstackConfiguration.new(config) }
+
+      it 'returns nil' do
+        expect(subject.url).to eq(nil)
+      end
+    end
+
+    context 'when `.config.yml` contains a browserstack section' do
+      let(:config) do
+        Quke::Configuration.file_location = data_path('.browserstack.yml')
+        Quke::Configuration.new
+      end
+      subject { Quke::BrowserstackConfiguration.new(config) }
+
+      it 'returns a string for the url to browserstack including the username and password' do
+        expect(subject.url).to eq(
+          'http://jdoe:123456789ABCDE@hub.browserstack.com/wd/hub'
+        )
+      end
+    end
+
+  end
+end

--- a/spec/quke/configuration_spec.rb
+++ b/spec/quke/configuration_spec.rb
@@ -190,38 +190,16 @@ RSpec.describe Quke::Configuration do
 
   describe '#use_proxy?' do
     context 'when proxy host details are NOT specified in the config file' do
-      it 'defaults to false' do
+      it 'returns false' do
         Quke::Configuration.file_location = data_path('.no_file.yml')
         expect(subject.use_proxy?).to eq(false)
       end
     end
 
     context 'when proxy host details are specified in the config file' do
-      it 'return true' do
+      it 'returns true' do
         Quke::Configuration.file_location = data_path('.proxy_basic.yml')
         expect(subject.use_proxy?).to eq(true)
-      end
-    end
-  end
-
-  describe '#browserstack' do
-    context 'when NOT specified in the config file' do
-      it 'defaults to a blank username, auth_key and empty capabilities hash' do
-        Quke::Configuration.file_location = data_path('.no_file.yml')
-        expect(subject.browserstack).to eq(
-          'username' => '',
-          'auth_key' => '',
-          'capabilities' => {}
-        )
-      end
-    end
-
-    context 'when specified in the config file' do
-      it 'matches the config file' do
-        Quke::Configuration.file_location = data_path('.simple.yml')
-        expected_config = YAML.load_file(data_path('.simple.yml'))['browserstack']
-
-        expect(subject.browserstack).to eq(expected_config)
       end
     end
   end
@@ -277,17 +255,6 @@ RSpec.describe Quke::Configuration do
           }
         )
       end
-    end
-  end
-
-  describe '#to_s' do
-    it 'return the values held by the instance and not an instance ID' do
-      Quke::Configuration.file_location = data_path('.no_file.yml')
-      # rubocop:disable Style/StringLiterals
-      expect(subject.to_s).to eq(
-        "{\"features_folder\"=>\"features\", \"app_host\"=>\"\", \"driver\"=>\"phantomjs\", \"pause\"=>0, \"stop_on_error\"=>\"false\", \"max_wait_time\"=>2, \"user_agent\"=>\"\", \"javascript_errors\"=>true, \"custom\"=>nil, \"browserstack\"=>{\"username\"=>\"\", \"auth_key\"=>\"\", \"capabilities\"=>{}}, \"proxy\"=>{\"host\"=>\"\", \"port\"=>0, \"no_proxy\"=>\"\"}}"
-      )
-      # rubocop:enable Style/StringLiterals
     end
   end
 

--- a/spec/quke/driver_configuration_spec.rb
+++ b/spec/quke/driver_configuration_spec.rb
@@ -223,28 +223,6 @@ RSpec.describe Quke::DriverConfiguration do
 
   end
 
-  describe '#browserstack_url' do
-
-    context 'browserstack details have NOT been set in the .config.yml' do
-      it 'returns nil' do
-        Quke::Configuration.file_location = data_path('.no_file.yml')
-        config = Quke::Configuration.new
-        expect(Quke::DriverConfiguration.new(config).browserstack_url).to eq(nil)
-      end
-    end
-
-    context 'browserstack details have been set in the .config.yml' do
-      it 'returns a string for the url to browserstack including the username and password' do
-        Quke::Configuration.file_location = data_path('.simple.yml')
-        config = Quke::Configuration.new
-        expect(Quke::DriverConfiguration.new(config).browserstack_url).to eq(
-          "http://#{config.browserstack['username']}:#{config.browserstack['auth_key']}@hub.browserstack.com/wd/hub"
-        )
-      end
-    end
-
-  end
-
   describe '#browserstack' do
 
     context 'browserstack details have NOT been set in the .config.yml' do

--- a/spec/quke/driver_registration_spec.rb
+++ b/spec/quke/driver_registration_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe Quke::DriverRegistration do
   describe '#register' do
 
     context 'A valid driver is passed to the method' do
-      %i(firefox chrome browserstack phantomjs).each do |driver|
+      %i[firefox chrome browserstack phantomjs].each do |driver|
         it "returns the value :#{driver} when that driver is selected" do
           Quke::Configuration.file_location = data_path(".#{driver}.yml")
           config = Quke::Configuration.new
           driver_config = Quke::DriverConfiguration.new(config)
-          driver_reg = Quke::DriverRegistration.new(driver_config)
+          driver_reg = Quke::DriverRegistration.new(driver_config, config)
           driver = driver_reg.register(config.driver)
           expect(driver).to eq(driver)
         end
@@ -21,7 +21,7 @@ RSpec.describe Quke::DriverRegistration do
         Quke::Configuration.file_location = data_path('.invalid.yml')
         config = Quke::Configuration.new
         driver_config = Quke::DriverConfiguration.new(config)
-        driver_reg = Quke::DriverRegistration.new(driver_config)
+        driver_reg = Quke::DriverRegistration.new(driver_config, config)
         driver = driver_reg.register(config.driver)
         expect(driver).to eq(driver)
       end

--- a/spec/quke/quke_spec.rb
+++ b/spec/quke/quke_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Quke do
   end
 
   describe '.execute' do
-    [:firefox, :chrome, :browserstack, :phantomjs].each do |driver|
+    %i[firefox chrome browserstack phantomjs].each do |driver|
       before(:example) do
         Quke::Configuration.file_location = data_path(".#{driver}.yml")
         Quke::Quke.config = Quke::Configuration.new


### PR DESCRIPTION
[Browserstack local testing](https://www.browserstack.com/local-testing) allows you to test private and internal servers, alongside public URL's. It does this by establishing a secure connection between your machine and BrowserStack servers.

We had previously attempted to support this when Quke was first put together however could not get it to work. At a recent hack day for Quke we were able to get local testing working using the latest method from Browserstack.

There is a binary which must be running when your test starts, and you simply need to set the Browserstack capability flag `browserstack.local` to `true`. For this change we're taking it a step further by having Quke install the binary as a dependency, and then manage starting and stopping it when required.

This keeps with our philosophy of Quke being a framework that makes acceptance testing simple.

This change seems quite large in proportion to the actual feature being added. This is because as we began adding methods to determine things like whether local testing was requested, and the args required to start the binary, we blew the size limits on Quke::Configuration. So it also includes a series of refactors, splitting anything related to configuring Browserstack into a separate configuration class.