### PR TITLE
Add missing support for local testing key env var

### DIFF
--- a/.config.example.yml
+++ b/.config.example.yml
@@ -105,7 +105,10 @@ browserstack:
 
   # If you want to use local testing you must provide a key. You can find this
   # in Browserstack once logged in under settings. Its typically the same value
-  # as the auth_key above
+  # as the auth_key above.
+  # If you don't want to put this credential in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variable BROWSERSTACK_LOCAL_KEY
   local_key: 123456789ABCDE
 
   # Anything set under capabilities will be passed directly by Quke to

--- a/README.md
+++ b/README.md
@@ -86,6 +86,32 @@ QUKE_CONFIG='chrome.config.yml' bundle exec quke
 
 The use case is to allow you to have different configs setup ready to go, and enable you to switch between them. For example when testing with Chrome and Firefox you set a 1 second delay between steps so you can observe the tests as they run through, but in your default `.config.yml` you want no pauses and use **phantomjs**.
 
+### Security
+
+If you are testing a site that requires some form of login, or you are using **Browserstack** you'll need to tell Quke about the credentials. Generally we advise not committing your `.config.yml` to source control, but we understand you may well build up a suite of them that you want to store with the project and share with others.
+
+If that's the case make use of the following features.
+
+#### Browserstack environment variables
+
+[.config.example.yml](.config.example.yml) is an example of a config file which contains `username`, `auth_key`, and if local testing `local_key`. You really don't want these becoming known so if you have to commit the config file, remove them and instead set the following environment variables wherever you need to run the tests.
+
+- BROWSERSTACK_USERNAME
+- BROWSERSTACK_AUTH_KEY
+- BROWSERSTACK_LOCAL_KEY
+
+Quke looks for them when configuring the **Browserstack** driver and only if not found does it then go looking in the config file.
+
+#### Ruby's ENV classs
+
+You can access any environment variable from within your project using [ENV](https://ruby-doc.org/core-2.4.2/ENV.html).
+
+```ruby
+secret_key = ENV['SUPER_SECRET_KEY']
+```
+
+You can set them by calling `export SUPER_SECRET_KEY="password123"` in your terminal prior to running Quke. In this way for example, the passwords featured in the custom section in [.config.example.yml](.config.example.yml) could be removed, and instead your step could read the value it needs to submit from an environment variable.
+
 ## Usage
 
 TODO: Write usage instructions here

--- a/lib/quke/browserstack_configuration.rb
+++ b/lib/quke/browserstack_configuration.rb
@@ -13,7 +13,10 @@ module Quke #:nodoc:
 
     # To use local testing users must provide a key. They will find this in
     # Browserstack once logged in under settings. Its typically the same value
-    # as the auth_key above
+    # as the auth_key above.
+    # If you don't want to put this credential in the config file (because you
+    # want to commit it to source control), Quke will also check for the
+    # existance of the environment variable BROWSERSTACK_LOCAL_KEY
     attr_reader :local_key
 
     # Capabilities are what configure the test in browserstack, for example
@@ -40,17 +43,21 @@ module Quke #:nodoc:
     # Initialize's the instance based in the +Quke::Configuration+ instance
     # passed in.
     #
+    # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/PerceivedComplexity
     def initialize(configuration)
       @using_browserstack = configuration.data['driver'] == 'browserstack'
       data = validate_input_data(configuration.data)
       @username = ENV['BROWSERSTACK_USERNAME'] || data['username'] || ''
       @auth_key = ENV['BROWSERSTACK_AUTH_KEY'] || data['auth_key'] || ''
-      @local_key = data['local_key'] || ''
+      @local_key = ENV['BROWSERSTACK_LOCAL_KEY'] || data['local_key'] || ''
       @capabilities = data['capabilities'] || {}
       determine_local_testing_args(configuration)
     end
+    # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/PerceivedComplexity
 
     # Return true if the +browserstack.local: true+ value has been set in the
     # +.config.yml+ file and the driver is set to 'browserstack', else false.

--- a/spec/data/.browserstack_no_credentials.yml
+++ b/spec/data/.browserstack_no_credentials.yml
@@ -1,0 +1,12 @@
+features: 'spec'
+driver: browserstack
+
+proxy:
+  host: '10.10.2.70'
+  port: 8080
+
+browserstack:
+  capabilities:
+    build: 'Version 1'
+    project: 'Adding browserstack support'
+    browserstack.local: true

--- a/spec/quke/browserstack_configuration_spec.rb
+++ b/spec/quke/browserstack_configuration_spec.rb
@@ -37,6 +37,34 @@ RSpec.describe Quke::BrowserstackConfiguration do
       end
 
     end
+
+    context 'when `.config.yml` contains a browserstack section but credentials are in env vars' do
+      let(:config) do
+        Quke::Configuration.file_location = data_path('.browserstack_no_credentials.yml')
+        Quke::Configuration.new
+      end
+      subject do
+        stub_const(
+          'ENV',
+          'BROWSERSTACK_USERNAME' => 'tstark',
+          'BROWSERSTACK_AUTH_KEY' => '123456789VWXYZ',
+          'BROWSERSTACK_LOCAL_KEY' => '123456789REDRU'
+        )
+        Quke::BrowserstackConfiguration.new(config)
+      end
+
+      it 'returns an instance with properties that match the input' do
+        expect(subject.username).to eq('tstark')
+        expect(subject.auth_key).to eq('123456789VWXYZ')
+        expect(subject.local_key).to eq('123456789REDRU')
+        expect(subject.capabilities).to eq(
+          'build' => 'Version 1',
+          'project' => 'Adding browserstack support',
+          'browserstack.local' => true
+        )
+      end
+
+    end
   end
 
   describe '#test_locally?' do


### PR DESCRIPTION
Having added support for local testing in 3089dc9 we forgot to also include setting this value via an environment variable.

Quke supports doing this for `username` and `auth_key`, so also needs to support doing the same for `local_key`.

This change rectifies that oversight.