### PR TITLE
Add ability to update browserstack session status

### DIFF
--- a/.browserstack.yml
+++ b/.browserstack.yml
@@ -1,0 +1,11 @@
+driver: browserstack
+
+browserstack:
+  username: alancruikshanks3
+  auth_key: PCTFnDxjvJpjypoyF1iu
+  local_key: PCTFnDxjvJpjypoyF1iu
+
+  capabilities:
+    build: 'Version 1'
+    project: 'Adding browserstack support'
+    name: 'Testing google search'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,9 +46,9 @@ Metrics/MethodLength:
   Max: 15
   Exclude:
 
-# It is our opinion that in the specs 80 characters is too restrictive. Do to
-# the nature of some statements that it can be both difficult, and make more
-# simple statements complex if we are forced to split them over multiple lines.
+# It is our opinion that in the specs 80 characters is too restrictive. Due to
+# the nature of some statements it can be both difficult, and make more simple
+# statements complex if we are forced to split them over multiple lines.
 # Therefore we have upped this limit to 120 chars in the specs only.
 Metrics/LineLength:
   Max: 120
@@ -56,6 +56,6 @@ Metrics/LineLength:
     - spec/quke/*.rb
 
 # Disable this rubocop style because we want to make the arguments passed into
-# Freakin available to anywhere when the code is executed
+# Quke available to anywhere when the code is executed
 Style/GlobalVars:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ env:
 # If grep returns 0 (match found), test 0 -eq 1 will return 1.
 # If grep returns 1 (no match found), test 1 -eq 1 will return 0.
 # If grep returns 2 (error), test 2 -eq 1 will return 1.
-before_script: >-
-  echo "Checking for use of 'focus' labels in specs" && grep -r --include="*_spec.rb" "focus: true" spec/; test $? -eq 1
+before_script:
+  - echo "Checking for use of 'focus' labels in specs" && grep -r --include="*_spec.rb" "focus&#58; true" spec/; test $? -eq 1
   # Setup to support the CodeClimate test coverage submission
   # As per CodeClimate's documentation, they suggest only running
   # ./cc-test-reporter commands on travis-ci push builds only. Hence we wrap all

--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ Capybara includes the ability to save the source of the current page at any poin
 
 If you are running using Chrome or Firefox after the 5th failure Quke will automatically stop. This is to prevent scores of tabs being opened in the browser when an error is found, which may just be the result of an error in the test code.
 
+### Automatically setting Browserstack session status
+
+If you are using the Browserstack driver, Quke will automatically update the status of the session recorded in Browserstack for you. If all tests pass, it will be marked as 'passed', else it will be marked as 'failed' (it defaults to 'completed').
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/bin/console
+++ b/bin/console
@@ -3,6 +3,8 @@
 require 'bundler/setup'
 require 'quke'
 require 'quke/version'
+require 'quke/browserstack_configuration'
+require 'quke/browserstack_status_reporter'
 require 'quke/configuration'
 require 'quke/cuke_runner'
 require 'quke/driver_registration'

--- a/lib/features/support/after_hook.rb
+++ b/lib/features/support/after_hook.rb
@@ -1,9 +1,13 @@
 require 'quke/configuration'
 
 After('~@nonweb') do |scenario|
-  if scenario.failed?
+  $fail_count ||= 0
 
-    $fail_count ||= 0
+  if Quke::Quke.config.browserstack.using_browserstack?
+    $session_id = page.driver.browser.session_id
+  end
+
+  if scenario.failed?
     $fail_count = $fail_count + 1
 
     # Tell Cucumber to quit after first failing scenario when stop_on_error is

--- a/lib/quke.rb
+++ b/lib/quke.rb
@@ -1,5 +1,6 @@
 require 'quke/version'
 require 'quke/browserstack_configuration'
+require 'quke/browserstack_status_reporter'
 require 'quke/configuration'
 require 'quke/cuke_runner'
 require 'quke/driver_registration'

--- a/lib/quke/browserstack_configuration.rb
+++ b/lib/quke/browserstack_configuration.rb
@@ -42,10 +42,11 @@ module Quke #:nodoc:
 
     # Initialize's the instance based in the +Quke::Configuration+ instance
     # passed in.
-    #
+    #--
     # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/PerceivedComplexity
+    #++
     def initialize(configuration)
       @using_browserstack = configuration.data['driver'] == 'browserstack'
       data = validate_input_data(configuration.data)
@@ -59,7 +60,7 @@ module Quke #:nodoc:
     # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/PerceivedComplexity
 
-    # Return true if the +browserstack.local: true+ value has been set in the
+    # Return true if the +browserstack.local+ value has been set to true in the
     # +.config.yml+ file and the driver is set to 'browserstack', else false.
     #
     # It is used when determing whether to start and stop the binary
@@ -74,7 +75,7 @@ module Quke #:nodoc:
     # to use in order to correctly determine is the browserstack local testing
     # binary needs to be stopped and started for the tests.
     #
-    # However it also serves as a clean and simple way ton determine if
+    # However it also serves as a clean and simple way to determine if
     # browserstack is the selected dribver.
     def using_browserstack?
       @using_browserstack

--- a/lib/quke/browserstack_status_reporter.rb
+++ b/lib/quke/browserstack_status_reporter.rb
@@ -1,0 +1,73 @@
+module Quke #:nodoc:
+
+  # Used to update the status of a session in Browserstack to mark it as passed
+  # or failed. It does this by making a PUT request to Browserstack's REST API
+  # requesting the status of a specified session is set to 'passed' or 'failed'
+  # (only those values are accepted).
+  #
+  # https://www.browserstack.com/automate/rest-api
+  #
+  # A session ID is only available when we configure Quke to work with
+  # Browserstack, and can only be obtained when in the context of running a
+  # scenario. It's unique to the overall session (it doesn't change for each
+  # scenario or feature), but we have to set it as a global variable in
+  # after_hook.rb in order to access it in the after_exit block in env.rb
+  class BrowserstackStatusReporter
+
+    # Initialize's the instance based in the +Quke::BrowserstackConfiguration+
+    # instance passed in.
+    #
+    # The values its interested in are username and auth_key as it will use
+    # these to authenticate with Browserstacks REST API.
+    def initialize(config)
+      @username = config.username
+      @auth_key = config.auth_key
+    end
+
+    # Connects to the Browserstack REST API and makes a PUT request to update
+    # the session with the matching +session_id+ to 'passed'.
+    #
+    # It returns a string which can be used as a message for output confirming
+    # the action.
+    def passed(session_id)
+      check_before_update(session_id, status: 'passed')
+      "Browserstack session #{session_id} status set to \e[32mpassed\e[0m 😀"
+    end
+
+    # Connects to the Browserstack REST API and makes a PUT request to update
+    # the session with the matching +session_id+ to 'failed'.
+    #
+    # It returns a string which can be used as a message for output confirming
+    # the action.
+    def failed(session_id)
+      check_before_update(session_id, status: 'failed')
+      "Browserstack session #{session_id} status set to \e[31mfailed\e[0m 😢"
+    end
+
+    private
+
+    def check_before_update(session_id, body)
+      raise(ArgumentError, 'Need a session ID to update browserstack status') if session_id.nil?
+
+      uri = URI("https://www.browserstack.com/automate/sessions/#{session_id}.json")
+      set_status(uri, body)
+    end
+
+    def set_status(uri, body)
+      request = Net::HTTP::Put.new(uri)
+      request.basic_auth @username, @auth_key
+      request.content_type = 'application/json'
+      request.body = body.to_json
+
+      response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+        http.request(request)
+      end
+
+      return if response.is_a? Net::HTTPSuccess
+
+      raise(StandardError, "Failed to update browserstack status: #{uri}")
+    end
+
+  end
+
+end

--- a/lib/quke/configuration.rb
+++ b/lib/quke/configuration.rb
@@ -152,6 +152,18 @@ module Quke #:nodoc:
       proxy['host'] != ''
     end
 
+    # Return the hash of +custom+ server settings
+    #
+    # This returns a hash of all the key/values in the custom section of your
+    # +.config.yml+ file. You can then access it in your steps/page objects with
+    #
+    #     Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
+    #     Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
+    #     Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+    #
+    # As long as what you add is valid YAML (check with a tool like
+    # http://www.yamllint.com/) Quke will be able to pick it up and make it
+    # available in your tests.
     def custom
       @data['custom']
     end

--- a/lib/quke/cuke_runner.rb
+++ b/lib/quke/cuke_runner.rb
@@ -22,8 +22,8 @@ module Quke #:nodoc:
     #   - +-r 'lib/features'+, tells Cucumber to require our features folder.
     #       This is how we get it to use our +env.rb+ which handles all the
     #       setup on behalf of the user (the point of Quke) to do things like
-    #       use Browserstack, or switch between running against Chrom or firefox
-    #       locally
+    #       use Browserstack, or switch between running against Chrome or
+    #       firefox locally
     #   - +-r my_features_folder+, if you specify a different folder for
     #       or wish to test just specific features, you are required by Cucumber
     #       to also require the folder which contains your steps
@@ -35,7 +35,7 @@ module Quke #:nodoc:
         # will take the next argument from that position, not from where the gem
         # currently sits. This means to Cucumber 'lib/features' doesn't exist,
         # which means our env.rb never gets loaded. Instead we first have to
-        # determing where this file is running from when called, then we simply
+        # determine where this file is running from when called, then we simply
         # replace the last part of that result (which we know will be lib/quke)
         # with lib/features. We then pass this full path to Cucumber so it can
         # correctly find the folder holding our predefined env.rb file.

--- a/lib/quke/version.rb
+++ b/lib/quke/version.rb
@@ -1,3 +1,3 @@
 module Quke #:nodoc:
-  VERSION = '0.5.0'.freeze
+  VERSION = '0.6.0'.freeze
 end

--- a/quke.gemspec
+++ b/quke.gemspec
@@ -100,5 +100,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rdoc', '~> 4.2'
   spec.add_development_dependency 'rspec', '~> 3.5'
   spec.add_development_dependency 'simplecov', '~> 0.13'
+  spec.add_development_dependency 'webmock', '~> 3.1'
 end
 # rubocop:enable Metrics/BlockLength

--- a/spec/quke/browserstack_status_reporter_spec.rb
+++ b/spec/quke/browserstack_status_reporter_spec.rb
@@ -1,0 +1,127 @@
+require 'spec_helper'
+
+RSpec.describe Quke::BrowserstackStatusReporter do
+  subject do
+    Quke::Configuration.file_location = data_path('.no_file.yml')
+    config = Quke::BrowserstackConfiguration.new(Quke::Configuration.new)
+    Quke::BrowserstackStatusReporter.new(config)
+  end
+
+  describe '#passed' do
+    context 'when the session_id is null' do
+      it 'raises an ArgumentError' do
+        expect { subject.passed }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'when the session_id is valid' do
+      before(:each) do
+        stub_request(:put, /browserstack/)
+          .with(
+            body: /passed/,
+            headers: {
+              'Accept' => '*/*',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'Authorization' => /Basic/,
+              'Content-Type' => 'application/json',
+              'Host' => 'www.browserstack.com',
+              'User-Agent' => 'Ruby'
+            }
+          )
+          .to_return(status: 200, body: '', headers: {})
+      end
+
+      it "succesfully updates the status to 'passed'" do
+        expect { subject.passed('6a22fe36d84d90ef18858f90f2c9cd2882eb082f') }.not_to raise_error
+      end
+
+      it "returns a message stating a given session's status was set to 'passed'" do
+        result = subject.passed('6a22fe36d84d90ef18858f90f2c9cd2882eb082f')
+        expect(result).to eq("Browserstack session 6a22fe36d84d90ef18858f90f2c9cd2882eb082f status set to \e[32mpassed\e[0m 😀")
+      end
+    end
+
+    context 'when the request fails' do
+      before(:each) do
+        stub_request(:put, /browserstack/)
+          .with(
+            body: /passed/,
+            headers: {
+              'Accept' => '*/*',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'Authorization' => /Basic/,
+              'Content-Type' => 'application/json',
+              'Host' => 'www.browserstack.com',
+              'User-Agent' => 'Ruby'
+            }
+          )
+          .to_return(status: 500, body: '', headers: {})
+      end
+
+      it 'raises an error' do
+        expect { subject.passed('6a22fe36d84d90ef18858f90f2c9cd2882eb082f') }.to raise_error(StandardError)
+      end
+
+    end
+  end
+
+  describe '#failed' do
+    context 'when the session_id is null' do
+      it 'raises an ArgumentError' do
+        expect { subject.failed }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'when the session_id is valid' do
+      before(:each) do
+        stub_request(:put, /browserstack/)
+          .with(
+            body: /failed/,
+            headers: {
+              'Accept' => '*/*',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'Authorization' => /Basic/,
+              'Content-Type' => 'application/json',
+              'Host' => 'www.browserstack.com',
+              'User-Agent' => 'Ruby'
+            }
+          )
+          .to_return(status: 200, body: '', headers: {})
+      end
+
+      it "succesfully updates the status to 'failed'" do
+        expect { subject.failed('6a22fe36d84d90ef18858f90f2c9cd2882eb082f') }.not_to raise_error
+      end
+
+      it "returns a message stating a given session's status was set to 'failed'" do
+        result = subject.failed('6a22fe36d84d90ef18858f90f2c9cd2882eb082f')
+        expect(result).to eq("Browserstack session 6a22fe36d84d90ef18858f90f2c9cd2882eb082f status set to \e[31mfailed\e[0m 😢")
+      end
+
+    end
+
+    context 'when the request fails' do
+      before(:each) do
+        stub_request(:put, /browserstack/)
+          .with(
+            body: /passed/,
+            headers: {
+              'Accept' => '*/*',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'Authorization' => /Basic/,
+              'Content-Type' => 'application/json',
+              'Host' => 'www.browserstack.com',
+              'User-Agent' => 'Ruby'
+            }
+          )
+          .to_return(status: 500, body: '', headers: {})
+      end
+
+      it 'raises an error' do
+        expect { subject.passed('6a22fe36d84d90ef18858f90f2c9cd2882eb082f') }.to raise_error(StandardError)
+      end
+
+    end
+
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,7 @@ end
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'helpers'
 require 'quke'
+require 'webmock/rspec'
 
 RSpec.configure do |config|
   # Enable the ability to run only selected tests. This means rather than


### PR DESCRIPTION
This change builds on our increased support for [Browserstack](https://www.browserstack.com). Each test run is recorded as a session in **BrowserStack**, and a session has a unique ID and a status. If you know the session ID, you can use **Browserstack's** REST API to set the status to 'passed' or 'failed' (the default is 'Completed').

With this change Quke will update the status for users automatically. It only applies when users have selected the `browserstack` driver, but if they have Quke will mark the session as 'passed' if all tests pass, else 'failed'.

It also includes some housekeeping (typos, documentation improvements, and some tweaks to our rubocop rules).