### PR TITLE
Fix broken gem exe config

### DIFF
--- a/quke.gemspec
+++ b/quke.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   # rubocop:enable Metrics/LineLength
 
   spec.files = Dir["{bin,exe,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
+  spec.bindir = "exe"
+  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.test_files = Dir["spec/**/*"]
 
   spec.require_paths = ["lib"]


### PR DESCRIPTION
We broke the gem, specifically its ability to be executed when we updated the gemspec to align with our other projects.

This adds back in the lines which should not have been deleted.