### PR TITLE
Update project dependencies

### DIFF
--- a/lib/features/support/after_hook.rb
+++ b/lib/features/support/after_hook.rb
@@ -6,7 +6,7 @@ require "quke/configuration"
 # any variables we set also need to be made global so they can be accessed
 # across the scenarios.
 # rubocop:disable Style/GlobalVars
-After("~@nonweb") do |scenario|
+After("not @nonweb") do |scenario|
   $fail_count ||= 0
 
   $session_id = page.driver.browser.session_id if Quke::Quke.config.browserstack.using_browserstack?

--- a/lib/features/support/before_hook.rb
+++ b/lib/features/support/before_hook.rb
@@ -2,7 +2,7 @@
 
 require "quke/configuration"
 
-Before("~@nonweb") do
+Before("not @nonweb") do
   # We have to make a special case for phantomjs when it comes to implementing
   # the ability to override the user agent. Unlike the selinium backed drivers
   # specifying the user agent is not part of the arguments we pass in when

--- a/lib/features/support/env.rb
+++ b/lib/features/support/env.rb
@@ -41,14 +41,6 @@ Capybara.run_server = false
 # which can mess up your project structure.
 Capybara.save_path = "tmp/"
 
-# By default, SitePrism element and section methods do not utilize Capybara's
-# implicit wait methodology and will return immediately if the element or
-# section requested is not found on the page. Adding the following code
-# enables Capybara's implicit wait methodology to pass through
-SitePrism.configure do |config|
-  config.use_implicit_waits = true
-end
-
 # There aren't specific hooks we can attach to that only get called once before
 # and after all tests have run in Cucumber. Therefore the next best thing is to
 # hook into the AfterConfiguration and at_exit blocks.

--- a/lib/quke.rb
+++ b/lib/quke.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "selenium/webdriver"
 require "chromedriver-helper"
 
 require "quke/version"

--- a/lib/quke.rb
+++ b/lib/quke.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "chromedriver-helper"
+
 require "quke/version"
 require "quke/browserstack_configuration"
 require "quke/browserstack_status_reporter"

--- a/lib/quke/version.rb
+++ b/lib/quke/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Quke #:nodoc:
-  VERSION = "0.6.0"
+  VERSION = "0.7.0"
 end

--- a/quke.gemspec
+++ b/quke.gemspec
@@ -95,10 +95,10 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "defra_ruby_style"
-  spec.add_development_dependency "github_changelog_generator", "~> 1.13"
-  spec.add_development_dependency "rake", "~> 10.5"
-  spec.add_development_dependency "rdoc", "~> 4.2"
-  spec.add_development_dependency "rspec", "~> 3.5"
-  spec.add_development_dependency "simplecov", "~> 0.13"
-  spec.add_development_dependency "webmock", "~> 3.1"
+  spec.add_development_dependency "github_changelog_generator"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rdoc"
+  spec.add_development_dependency "rspec", "~> 3.8"
+  spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "webmock", "~> 3.5"
 end

--- a/quke.gemspec
+++ b/quke.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # as possible we have gone with using the chromedriver-helper. To quote
   # from it "Easy installation and use of chromedriver, the Chromium project's
   # selenium webdriver adapter."
-  spec.add_dependency "chromedriver-helper", "~> 1.0"
+  spec.add_dependency "chromedriver-helper", "~> 2.1"
 
   # Experience has shown that keeping tests dry helps make them more
   # maintainable over time. One practice that helps is the use of the

--- a/quke.gemspec
+++ b/quke.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.4"
 
   # We need the cucumber gem to use cucumber, obviously!
-  spec.add_dependency "cucumber", "~> 2.4"
+  spec.add_dependency "cucumber", "~> 3.1"
 
   # We use capybara to drive whichever browser we are using, and by drive we
   # mean things like fill_in x, click_on y etc. Capybara makes it much easier to

--- a/quke.gemspec
+++ b/quke.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |spec|
   # We bring in rspec-expectations to simplify how to actually test if a page is
   # correct. For example you can test you are on the right page in a step using
   # expect(page).to have_text 'Welcome to test nirvana!'
-  spec.add_dependency "rspec-expectations", "~> 3.4"
+  spec.add_dependency "rspec-expectations", "~> 3.8"
 
   # This is the first of our web drivers i.e. the bits that allow capybara to
   # to drive an actual browser. Poltergeist is used with a headless browser

--- a/quke.gemspec
+++ b/quke.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |spec|
   # to drive an actual browser. Poltergeist is used with a headless browser
   # called phantomjs, which is superfast and great for using on CI servers
   # as it has no other dependencies
-  spec.add_dependency "poltergeist", "~> 1.10"
+  spec.add_dependency "poltergeist", "~> 1.18"
 
   # selenium-webdriver is used to drive real browsers that may be installed,
   # for example Firefox, Chrome and Internet Explorer. The benefit of selenium

--- a/quke.gemspec
+++ b/quke.gemspec
@@ -80,7 +80,7 @@ Gem::Specification.new do |spec|
   # different steps. Site_Prism provides a page object framework, and we build
   # it into the gem so users of Quke don't have to add and setup this dependency
   # themselves
-  spec.add_dependency "site_prism", "~> 2.9"
+  spec.add_dependency "site_prism", "~> 3.0"
 
   # Capybara includes a method called save_and_open_page. Without Launchy it
   # will still save to file a copy of the source html of the page in question

--- a/quke.gemspec
+++ b/quke.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |spec|
   # mean things like fill_in x, click_on y etc. Capybara makes it much easier to
   # do this, though if you're willing to go a level lower you can write your own
   # code to tell selenium how to interact with a web page
-  spec.add_dependency "capybara", "~> 2.9"
+  spec.add_dependency "capybara", "~> 3.14"
 
   # We bring in rspec-expectations to simplify how to actually test if a page is
   # correct. For example you can test you are on the right page in a step using

--- a/quke.gemspec
+++ b/quke.gemspec
@@ -62,7 +62,7 @@ Gem::Specification.new do |spec|
   # for example Firefox, Chrome and Internet Explorer. The benefit of selenium
   # is you can actually see the tests interacting with the browser, the downside
   # is they run slower and isn't best suited to a CI environment.
-  spec.add_dependency "selenium-webdriver", "~> 2.53"
+  spec.add_dependency "selenium-webdriver", "~> 3.14"
 
   # Needed when wishing to use Chrome for selenium tests. We could have chosen
   # to install the chromedriver separately (and it seems more recent tutorials
@@ -71,6 +71,14 @@ Gem::Specification.new do |spec|
   # from it "Easy installation and use of chromedriver, the Chromium project's
   # selenium webdriver adapter."
   spec.add_dependency "chromedriver-helper", "~> 2.1"
+
+  # Needed when wishing to use Firefox for selenium tests. We could have chosen
+  # to install the geckodriver separately. However in an effort to make using
+  # this gem as simple as possible we have gone with using the
+  # geckodriver-helper. To quote from it "Easy installation and use of
+  # geckodriver, that provides the HTTP API described by the WebDriver protocol
+  # to communicate with Gecko browsers, such as Firefox."
+  spec.add_dependency "geckodriver-helper", "~> 0.23"
 
   # Experience has shown that keeping tests dry helps make them more
   # maintainable over time. One practice that helps is the use of the


### PR DESCRIPTION
It has been a long time since Quke's dependencies were updated.

These changes are as a result of updating all our dependencies to the latest and greatest possible. Key updates were

 - **development dependencies** - All dependencies have been updated as well as some for the version specifiers being removed. Generally we want the latest and greatest when it comes to these so don't need to be cautious and restrict the versions.
 - **rspec** - Mainly the expectations which Quke uses to support using asserts in tests.
 - **site_prism** - SitePrism has gone 3.0 since our last updates to Quke. So we have updated to the latest and made some minor changes around config and tags based on its update notes.
 - **chromedriver helper** - As well as updating the gem the latest docs say you also need to `require` it in your app to prevent `unable to connect to chromedriver 127.0.0.1:9515 (Selenium::WebDriver::Error::WebDriverError)` errors (which we got after just updating the gem). It also instructs you to require `selenium-webdriver` before `chromedriver` so we added that in as well.
 - **Poltergeist**
 - **Capybara**

Finally we also managed to update **selenium-webdriver**. We needed to update selenium as Quke was stuck only being able to support testing of Firefox v47 or less due to the change to using Geckodriver in Firefox 48.

When this first happened we help off updating Quke as selenium-webdriver did not have full support yet for Geckodriver.

Since then though those issue have been supported and the latest Selenium Webdriver supports the latest Firefox versions.

The one change is, like chrome an additional driver needs to be installed to drive Firefox. Hence the addition of `geckodriver-helper` which is a project that mirrors the way `chromedriver-helper` works to install and manage the geckodriver binary for you, rather than having to download and start it separately outside your tests.
