### PR TITLE
Update Selenium to use Options

### DIFF
--- a/lib/quke/driver_registration.rb
+++ b/lib/quke/driver_registration.rb
@@ -74,15 +74,19 @@ module Quke #:nodoc:
     # to work with firefox hence we refer to it as :firefox
     def firefox
       # For future reference configuring Firefox via Selenium appears to be done
-      # via the profile argument, and a Selenium::WebDriver::Firefox::Profile
+      # via the options argument, and a Selenium::WebDriver::Firefox::Options
       # object.
-      # https://github.com/SeleniumHQ/selenium/wiki/Ruby-Bindings#firefox
-      # http://www.rubydoc.info/gems/selenium-webdriver/0.0.28/Selenium/WebDriver/Firefox/Profile
+      # https://github.com/SeleniumHQ/selenium/wiki/Ruby-Bindings
+      # https://www.rubydoc.info/gems/selenium-webdriver/3.141.0/Selenium/WebDriver/Firefox/Options
       # http://www.seleniumhq.org/docs/04_webdriver_advanced.jsp
       # http://preferential.mozdev.org/preferences.html
       Capybara.register_driver :firefox do |app|
         # :simplecov_ignore:
-        Capybara::Selenium::Driver.new(app, profile: @driver_config.firefox)
+        Capybara::Selenium::Driver.new(
+          app,
+          browser: :firefox,
+          options: @driver_config.firefox
+        )
         # :simplecov_ignore:
       end
       :firefox
@@ -92,9 +96,9 @@ module Quke #:nodoc:
     # to work with chrome.
     def chrome
       # For future reference configuring Chrome via Selenium appears to be done
-      # use the switches argument, which I understand is essentially passed by
+      # use the options argument, which I understand is essentially passed by
       # Capybara to Selenium-webdriver, which in turn passes it to chromium
-      # https://github.com/SeleniumHQ/selenium/wiki/Ruby-Bindings#chrome
+      # https://github.com/SeleniumHQ/selenium/wiki/Ruby-Bindings
       # http://peter.sh/experiments/chromium-command-line-switches/
       # https://www.chromium.org/developers/design-documents/network-settings
       Capybara.register_driver :chrome do |app|
@@ -102,7 +106,7 @@ module Quke #:nodoc:
         Capybara::Selenium::Driver.new(
           app,
           browser: :chrome,
-          switches: @driver_config.chrome
+          options: @driver_config.chrome
         )
         # :simplecov_ignore:
       end

--- a/spec/quke/driver_configuration_spec.rb
+++ b/spec/quke/driver_configuration_spec.rb
@@ -113,19 +113,19 @@ RSpec.describe Quke::DriverConfiguration do
   describe "#chrome" do
 
     context "proxy details have NOT been set in the .config.yml" do
-      it "returns an empty array if no proxy has been set" do
+      it "returns an instance of Chrome::Options where the proxy details are NOT set" do
         Quke::Configuration.file_location = data_path(".no_file.yml")
         config = Quke::Configuration.new
-        expect(Quke::DriverConfiguration.new(config).chrome).to eq([])
+        expect(Quke::DriverConfiguration.new(config).chrome.args).to eq(Set[])
       end
     end
 
     context "basic proxy details have been set in the .config.yml" do
-      it "returns an array containing basic proxy settings" do
+      it "returns an instance of Chrome::Options containing basic proxy settings" do
         Quke::Configuration.file_location = data_path(".proxy_basic.yml")
         config = Quke::Configuration.new
-        expect(Quke::DriverConfiguration.new(config).chrome).to eq(
-          [
+        expect(Quke::DriverConfiguration.new(config).chrome.args).to eq(
+          Set[
             "--proxy-server=#{config.proxy['host']}:#{config.proxy['port']}"
           ]
         )
@@ -133,11 +133,11 @@ RSpec.describe Quke::DriverConfiguration do
     end
 
     context "proxy details including addresses not to connect via the proxy server have been set in the .config.yml" do
-      it "returns an array containing proxy settings including no-proxy details" do
+      it "returns an instance of Chrome::Options containing proxy settings including no-proxy details" do
         Quke::Configuration.file_location = data_path(".proxy.yml")
         config = Quke::Configuration.new
-        expect(Quke::DriverConfiguration.new(config).chrome).to eq(
-          [
+        expect(Quke::DriverConfiguration.new(config).chrome.args).to eq(
+          Set[
             "--proxy-server=#{config.proxy['host']}:#{config.proxy['port']}",
             "--proxy-bypass-list=127.0.0.1;192.168.0.1"
           ]
@@ -146,11 +146,11 @@ RSpec.describe Quke::DriverConfiguration do
     end
 
     context "a user agent has been set in the .config.yml" do
-      it "returns an array containing the specified user-agent" do
+      it "returns an instance of Chrome::Options containing the specified user-agent" do
         Quke::Configuration.file_location = data_path(".user_agent.yml")
         config = Quke::Configuration.new
-        expect(Quke::DriverConfiguration.new(config).chrome).to eq(
-          [
+        expect(Quke::DriverConfiguration.new(config).chrome.args).to eq(
+          Set[
             "--user-agent=#{config.user_agent}"
           ]
         )
@@ -162,10 +162,10 @@ RSpec.describe Quke::DriverConfiguration do
   describe "#firefox" do
 
     context "proxy details have NOT been set in the .config.yml" do
-      it "returns a profile where the proxy details are NOT set" do
+      it "returns an instance of Firefox::Options where the proxy details are NOT set" do
         Quke::Configuration.file_location = data_path(".no_file.yml")
         config = Quke::Configuration.new
-        profile = Quke::DriverConfiguration.new(config).firefox
+        profile = Quke::DriverConfiguration.new(config).firefox.profile
 
         # See spec/helpers.rb#read_profile_preferences for details of why we
         # need to test the profile's properties in this way
@@ -177,10 +177,10 @@ RSpec.describe Quke::DriverConfiguration do
     end
 
     context "basic proxy details have been set in the .config.yml" do
-      it "returns a profile where the basic proxy details are set" do
+      it "returns an instance of Firefox::Options containing basic proxy settings" do
         Quke::Configuration.file_location = data_path(".proxy_basic.yml")
         config = Quke::Configuration.new
-        profile = Quke::DriverConfiguration.new(config).firefox
+        profile = Quke::DriverConfiguration.new(config).firefox.profile
 
         # See spec/helpers.rb#read_profile_preferences for details of why we
         # need to test the profile's properties in this way
@@ -192,10 +192,10 @@ RSpec.describe Quke::DriverConfiguration do
     end
 
     context "proxy details including addresses not to connect via the proxy server have been set in the .config.yml" do
-      it "returns a profile where the proxy details are set including no-proxy details" do
+      it "returns an instance of Firefox::Options containing proxy settings including no-proxy details" do
         Quke::Configuration.file_location = data_path(".proxy.yml")
         config = Quke::Configuration.new
-        profile = Quke::DriverConfiguration.new(config).firefox
+        profile = Quke::DriverConfiguration.new(config).firefox.profile
 
         # See spec/helpers.rb#read_profile_preferences for details of why we
         # need to test the profile's properties in this way
@@ -208,10 +208,10 @@ RSpec.describe Quke::DriverConfiguration do
     end
 
     context "a user agent has been set in the .config.yml" do
-      it "returns an array containing the specified user-agent" do
+      it "returns an instance of Firefox::Options containing the specified user-agent" do
         Quke::Configuration.file_location = data_path(".user_agent.yml")
         config = Quke::Configuration.new
-        profile = Quke::DriverConfiguration.new(config).firefox
+        profile = Quke::DriverConfiguration.new(config).firefox.profile
 
         # See spec/helpers.rb#read_profile_preferences for details of why we
         # need to test the profile's properties in this way


### PR DESCRIPTION
Since the update to selenium we have been getting deprecation warnings about the use of the `switches:` argument when registering the chrome driver, and the `profile:` argument when registering Firefox.

These have both been deprecated in favour of using `options:`.

So this change updates Quke to use the new way of passing our configuration to the driver when registering it via Capybara.