### PR TITLE
Add support for headless chrome and firefox

### DIFF
--- a/.config.example.yml
+++ b/.config.example.yml
@@ -15,6 +15,14 @@ app_host: 'https://en.wikipedia.org/wiki'
 # browserstack and phantomjs, with the default being phantomjs
 driver: chrome
 
+# Let Quke know you want to run the browser in headless mode. Headless mode
+# means the browser still runs but you won't see it displayed. The benefit is
+# that your tests will take less time as it's less resource intensive.
+# This option only applies when the driver is set to 'chrome' or 'firefox'.
+# Phantomjs is a headless only browser, and option is meaningless for
+# browserstack
+headless: true
+
 # Add a pause (in seconds) between steps so you can visually track how the
 # browser is responding. Only useful if using a non-headless browser. The
 # default is 0

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ You should be aware of some default behaviours included in Quke.
 
 ### Displaying web pages on fail
 
-Capybara includes the ability to save the source of the current page at any point. Quke has been configured so that if you are not using the headless browser and a step should fail it will save the source to file and then use a tool called [Launchy](https://github.com/copiousfreetime/launchy) to open it in your default browser.
+Capybara includes the ability to save the source of the current page at any point. Quke has been configured so that if you are not using a headless browser and a step fails it will save the source to file and then use a tool called [Launchy](https://github.com/copiousfreetime/launchy) to open it in your default browser.
 
 ### Quit on 5 failures
 

--- a/lib/features/support/after_hook.rb
+++ b/lib/features/support/after_hook.rb
@@ -23,13 +23,13 @@ After("not @nonweb") do |scenario|
     if Quke::Quke.config.stop_on_error || $fail_count >= 5
       Cucumber.wants_to_quit = true
     else
-      # If we're not using poltergiest and the scenario has failed, we want
-      # to save a copy of the page and open it automatically using Launchy.
-      # We wrap this in a begin/rescue in case of any issues in which case
-      # it defaults to outputting the source to STDOUT.
+      # If we're not using poltergiest or running in headless mode and the
+      # scenario has failed, we want to save a copy of the page and open it
+      # automatically using Launchy. We wrap this in a begin/rescue in case of
+      # any issues in which case it defaults to outputting the source to STDOUT.
       begin
         # rubocop:disable Lint/Debugger
-        save_and_open_page
+        save_and_open_page unless Quke::Quke.config.headless
         # rubocop:enable Lint/Debugger
       rescue StandardError
         # handle e

--- a/lib/quke/configuration.rb
+++ b/lib/quke/configuration.rb
@@ -79,6 +79,14 @@ module Quke #:nodoc:
       @data["driver"]
     end
 
+    # Returns the value set for +headless+.
+    #
+    # Tells Quke whether to drive the browser in headless mode. Only applicable
+    # if +driver+ is set to 'chrome' or 'firefox'.
+    def headless
+      @data["headless"]
+    end
+
     # Return the value set for +pause+.
     #
     # Add a pause (in seconds) between steps so you can visually track how the
@@ -188,6 +196,7 @@ module Quke #:nodoc:
         "features_folder" => (data["features"] || "features").downcase.strip,
         "app_host" => (data["app_host"] || "").downcase.strip,
         "driver" => (data["driver"] || "phantomjs").downcase.strip,
+        "headless" => (data["headless"].to_s.downcase.strip == "true"),
         "pause" => (data["pause"] || "0").to_s.downcase.strip.to_i,
         "stop_on_error" => (data["stop_on_error"] || "false").to_s.downcase.strip,
         "max_wait_time" => (data["max_wait_time"] || Capybara.default_max_wait_time).to_s.downcase.strip.to_i,

--- a/lib/quke/driver_configuration.rb
+++ b/lib/quke/driver_configuration.rb
@@ -152,6 +152,8 @@ module Quke #:nodoc:
       no_proxy = config.proxy["no_proxy"].tr(",", ";")
 
       options = Selenium::WebDriver::Chrome::Options.new
+      options.headless! if config.headless
+
       options.add_argument("--proxy-server=#{host}:#{port}") if config.use_proxy?
       options.add_argument("--proxy-bypass-list=#{no_proxy}") unless config.proxy["no_proxy"].empty?
 
@@ -190,17 +192,10 @@ module Quke #:nodoc:
     #     )
     #
     def firefox
-      profile = Selenium::WebDriver::Firefox::Profile.new
-      profile["general.useragent.override"] = config.user_agent unless config.user_agent.empty?
+      options = Selenium::WebDriver::Firefox::Options.new(profile: firefox_profile)
+      options.headless! if config.headless
 
-      settings = {}
-      settings[:http] = "#{config.proxy['host']}:#{config.proxy['port']}" if config.use_proxy?
-      settings[:ssl] = settings[:http] if config.use_proxy?
-      settings[:no_proxy] = config.proxy["no_proxy"] unless config.proxy["no_proxy"].empty?
-
-      profile.proxy = Selenium::WebDriver::Proxy.new(settings) if config.use_proxy?
-
-      Selenium::WebDriver::Firefox::Options.new(profile: profile)
+      options
     end
 
     # Returns an instance of Selenium::WebDriver::Remote::Capabilities to be
@@ -246,6 +241,22 @@ module Quke #:nodoc:
       end
 
       capabilities
+    end
+
+    private
+
+    def firefox_profile
+      profile = Selenium::WebDriver::Firefox::Profile.new
+      profile["general.useragent.override"] = config.user_agent unless config.user_agent.empty?
+
+      settings = {}
+      settings[:http] = "#{config.proxy['host']}:#{config.proxy['port']}" if config.use_proxy?
+      settings[:ssl] = settings[:http] if config.use_proxy?
+      settings[:no_proxy] = config.proxy["no_proxy"] unless config.proxy["no_proxy"].empty?
+
+      profile.proxy = Selenium::WebDriver::Proxy.new(settings) if config.use_proxy?
+
+      profile
     end
 
   end

--- a/spec/data/.as_string.yml
+++ b/spec/data/.as_string.yml
@@ -4,6 +4,7 @@ pause: '1'
 
 stop_on_error: 'true'
 max_wait_time: '3'
+headless: 'true'
 javascript_errors: 'false'
 
 proxy:

--- a/spec/data/.headless.yml
+++ b/spec/data/.headless.yml
@@ -1,0 +1,1 @@
+headless: true

--- a/spec/quke/configuration_spec.rb
+++ b/spec/quke/configuration_spec.rb
@@ -51,6 +51,29 @@ RSpec.describe Quke::Configuration do
     end
   end
 
+  describe "#headless" do
+    context "when NOT specified in the config file" do
+      it "defaults to false" do
+        Quke::Configuration.file_location = data_path(".no_file.yml")
+        expect(subject.headless).to eq(false)
+      end
+    end
+
+    context "when specified in the config file" do
+      it "matches the config file" do
+        Quke::Configuration.file_location = data_path(".headless.yml")
+        expect(subject.headless).to eq(true)
+      end
+    end
+
+    context "when in the config file as a string" do
+      it "matches the config file" do
+        Quke::Configuration.file_location = data_path(".as_string.yml")
+        expect(subject.headless).to eq(true)
+      end
+    end
+  end
+
   describe "#pause" do
     context "when NOT specified in the config file" do
       it "defaults to 0" do

--- a/spec/quke/driver_configuration_spec.rb
+++ b/spec/quke/driver_configuration_spec.rb
@@ -157,6 +157,14 @@ RSpec.describe Quke::DriverConfiguration do
       end
     end
 
+    context "headless mode has been set in the .config.yml" do
+      it "returns an instance of Chrome::Options set to run the browser in headless mode" do
+        Quke::Configuration.file_location = data_path(".headless.yml")
+        config = Quke::Configuration.new
+        expect(Quke::DriverConfiguration.new(config).chrome.args).to eq(Set["--headless"])
+      end
+    end
+
   end
 
   describe "#firefox" do
@@ -220,6 +228,14 @@ RSpec.describe Quke::DriverConfiguration do
         expect(preferences).to include(
           'user_pref("general.useragent.override", "Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)")'
         )
+      end
+    end
+
+    context "headless mode has been set in the .config.yml" do
+      it "returns an instance of Firefox::Options set to run the browser in headless mode" do
+        Quke::Configuration.file_location = data_path(".headless.yml")
+        config = Quke::Configuration.new
+        expect(Quke::DriverConfiguration.new(config).chrome.args).to eq(Set["--headless"])
       end
     end
 


### PR DESCRIPTION
Now Quke has been updated and is using the latest Selenium Webdriver, we can take advantage of the fact they both Chrome and Firefox have a headless mode.

This change adds the ability to tell Quke you wish to use either Chrome or Firefox in their headless mode.

As per phantomjs, we have followed the same behaviour of not launching a view of the error page in the event of an error so the experience is truly headless.