### PR TITLE
Add support for running tests in parallel

### DIFF
--- a/.config.example.yml
+++ b/.config.example.yml
@@ -4,6 +4,16 @@
 # The default is features
 features_folder: 'cukes'
 
+# Tell Quke you want to run tests in parallel. This will make use of the
+# available cores on your machine to run the tests in parallel, reducing the
+# time it takes them to run.
+#
+# This is great if you have a large test suite (the performance improvement is
+# egligible if you only have a few). However your scenarios must be independent,
+# and the console output will be 'number of processes' * cucumber output. So
+# this is best used if you are just after a simple pass/fail result.
+parrellel: true
+
 # Normally Capybara expects to be testing an in-process Rack application, but
 # we're using it to talk to a remote host. Users of Quke can set what this
 # will be by simply setting `app_host`. You can then use it directly using
@@ -11,7 +21,7 @@ features_folder: 'cukes'
 # the full url each time
 app_host: 'https://en.wikipedia.org/wiki'
 
-# Tells Quke which browser to use for testing. Choices are firefox, chrome
+# Tells Quke which browser to use for testing. Choices are firefox, chrome,
 # browserstack and phantomjs, with the default being phantomjs
 driver: chrome
 

--- a/exe/quke
+++ b/exe/quke
@@ -5,7 +5,5 @@
 # rubocop:enable Layout/LeadingCommentSpace
 
 require "quke"
-require "quke/configuration"
 
-Quke::Quke.config = Quke::Configuration.new
 Quke::Quke.execute(ARGV)

--- a/lib/features/support/env.rb
+++ b/lib/features/support/env.rb
@@ -3,11 +3,14 @@
 require "rspec/expectations"
 require "capybara/cucumber"
 require "site_prism"
+require "quke"
 require "quke/configuration"
 require "quke/driver_configuration"
 require "quke/driver_registration"
 require "browserstack/local"
 require "quke/browserstack_status_reporter"
+
+Quke::Quke.config = Quke::Configuration.new
 
 Capybara.app_host = Quke::Quke.config.app_host unless Quke::Quke.config.app_host.empty?
 

--- a/lib/quke.rb
+++ b/lib/quke.rb
@@ -2,6 +2,7 @@
 
 require "selenium/webdriver"
 require "chromedriver-helper"
+require "byebug"
 
 require "quke/version"
 require "quke/browserstack_configuration"
@@ -25,7 +26,7 @@ module Quke #:nodoc:
 
     # The entry point for Quke, it is the one call made by +exe/quke+.
     def self.execute(args = [])
-      cuke = CukeRunner.new(@config.features_folder, args)
+      cuke = CukeRunner.new(args)
       cuke.run
     end
 

--- a/lib/quke/configuration.rb
+++ b/lib/quke/configuration.rb
@@ -87,6 +87,21 @@ module Quke #:nodoc:
       @data["headless"]
     end
 
+    # Returns the value set for +parallel+.
+    #
+    # Tells Quke whether run the features in parallel. Depending on the number
+    # of cores on the host machine, it will split the features across a given
+    # number of processes and run them in parallel.
+    #
+    # This is great if you have a large test suite (the performance improvement
+    # is negligible if you only have a few). However your scenarios must be
+    # independent, and the console output will be 'number of processes' *
+    # cucumber output. This is best used if you are just after a simple
+    # pass/fail result.
+    def parallel
+      @data["parallel"]
+    end
+
     # Return the value set for +pause+.
     #
     # Add a pause (in seconds) between steps so you can visually track how the
@@ -197,6 +212,7 @@ module Quke #:nodoc:
         "app_host" => (data["app_host"] || "").downcase.strip,
         "driver" => (data["driver"] || "phantomjs").downcase.strip,
         "headless" => (data["headless"].to_s.downcase.strip == "true"),
+        "parallel" => (data["parallel"].to_s.downcase.strip == "true"),
         "pause" => (data["pause"] || "0").to_s.downcase.strip.to_i,
         "stop_on_error" => (data["stop_on_error"] || "false").to_s.downcase.strip,
         "max_wait_time" => (data["max_wait_time"] || Capybara.default_max_wait_time).to_s.downcase.strip.to_i,

--- a/lib/quke/cuke_runner.rb
+++ b/lib/quke/cuke_runner.rb
@@ -1,19 +1,22 @@
 # frozen_string_literal: true
 
 require "cucumber"
+require "parallel_tests"
 
 module Quke #:nodoc:
 
   # Handles executing Cucumber, including sorting the arguments we pass to it
   class CukeRunner
 
-    # # Access the arguments used by Quke when it was executed
+    # Access the arguments used by Quke when it was executed
     attr_reader :args
 
     # When an instance of CukeRunner is initialized it will take the arguments
-    # passed in and combine them with its own default args.
+    # passed in and combine them with its own default args. Those args are a mix
+    # of ones specific to ParallelTests, and ones for Cucumber.
     #
-    # The default args add the following to the parameters passed to Cucumber
+    # In essence we are getting ParallelTests to pass the following to Cucumber
+    # along with whatever args are passed in when Quke is called.
     #
     #     [my_features_folder, '-r', 'lib/features', '-r', my_features_folder]
     #
@@ -28,31 +31,53 @@ module Quke #:nodoc:
     #       firefox locally
     #   - +-r my_features_folder+, if you specify a different folder for
     #       or wish to test just specific features, you are required by Cucumber
-    #       to also require the folder which contains your steps
-    # features directory contains the +env.rb+
-    def initialize(features_folder, args = [])
-      @args = [
-        features_folder,
-        # Because cucumber is called in the context of the executing script it
-        # will take the next argument from that position, not from where the gem
-        # currently sits. This means to Cucumber 'lib/features' doesn't exist,
-        # which means our env.rb never gets loaded. Instead we first have to
-        # determine where this file is running from when called, then we simply
-        # replace the last part of that result (which we know will be lib/quke)
-        # with lib/features. We then pass this full path to Cucumber so it can
-        # correctly find the folder holding our predefined env.rb file.
-        "-r", __dir__.sub!("lib/quke", "lib/features"),
-        "-r", features_folder
-      ] + args
+    #       to also require the folder which contains your steps. So we always
+    #       set this to be sure to handle tagged scenarios, or features run in
+    #       parallel.
+    def initialize(passed_in_args = [])
+      Quke.config = Configuration.new
+      @args = parallel_args + test_options_args(passed_in_args)
     end
 
-    # Executes Cucumber, passing in the arguments hash set when the instance of
-    # CukeRunner was created.
+    # Executes ParallelTests, which in turn executes Cucumber passing in the
+    # arguments defined when the instance of CukeRunner was initialized.
     def run
-      Cucumber::Cli::Main.new(@args).execute!
+      ParallelTests::CLI.new.run(@args)
     rescue SystemExit => e
       # Cucumber calls @kernel.exit() killing your script unless you rescue
       raise StandardError, "Cucumber exited in a failed state" unless e.success?
+    end
+
+    private
+
+    def parallel_args
+      args = [
+        Quke.config.features_folder,
+        "--type", "cucumber",
+        "--serialize-stdout",
+        "--combine-stderr"
+      ]
+      args += ["--single", "--quiet"] unless Quke.config.parallel
+      args
+    end
+
+    def test_options_args(passed_in_args)
+      # Because cucumber is called in the context of the executing project and
+      # not Quke it will take its arguments in the context of that location, and
+      # not from where the Quke currently sits. This means to Cucumber
+      # 'lib/features' doesn't exist, which means our env.rb never gets loaded.
+      # Instead we first have to determine where this file is running from when
+      # called, then we simply replace the last part of that result (which we
+      # know will be lib/quke) with lib/features. For example __dir__ returns
+      # '/Users/acruikshanks/projects/defra/quke/lib/quke' but we need Cucumber
+      # to load '/Users/acruikshanks/projects/defra/quke/lib/features'
+      # We then pass this full path to Cucumber so it can correctly find the
+      # folder holding our predefined env.rb file.
+      env_folder = __dir__.sub!("lib/quke", "lib/features")
+      [
+        "--test-options",
+        "--format pretty -r #{env_folder} -r #{Quke.config.features_folder} #{passed_in_args.join(' ')}"
+      ]
     end
 
   end

--- a/lib/quke/version.rb
+++ b/lib/quke/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Quke #:nodoc:
-  VERSION = "0.8.0"
+  VERSION = "0.9.0"
 end

--- a/quke.gemspec
+++ b/quke.gemspec
@@ -101,6 +101,10 @@ Gem::Specification.new do |spec|
   # and provides an API for managing it.
   spec.add_dependency "browserstack-local"
 
+  # The Parallel tests gem supports running rspec and cucumber tests in
+  # parallel, which should reduce the time it takes for a suite to run.
+  spec.add_dependency "parallel_tests", "~> 2.28"
+
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "defra_ruby_style"
   spec.add_development_dependency "github_changelog_generator"

--- a/spec/data/.as_string.yml
+++ b/spec/data/.as_string.yml
@@ -5,6 +5,7 @@ pause: '1'
 stop_on_error: 'true'
 max_wait_time: '3'
 headless: 'true'
+parallel: 'true'
 javascript_errors: 'false'
 
 proxy:

--- a/spec/data/.parallel.yml
+++ b/spec/data/.parallel.yml
@@ -1,0 +1,1 @@
+parallel: true

--- a/spec/quke/configuration_spec.rb
+++ b/spec/quke/configuration_spec.rb
@@ -74,6 +74,29 @@ RSpec.describe Quke::Configuration do
     end
   end
 
+  describe "#parallel" do
+    context "when NOT specified in the config file" do
+      it "defaults to false" do
+        Quke::Configuration.file_location = data_path(".no_file.yml")
+        expect(subject.parallel).to eq(false)
+      end
+    end
+
+    context "when specified in the config file" do
+      it "matches the config file" do
+        Quke::Configuration.file_location = data_path(".parallel.yml")
+        expect(subject.parallel).to eq(true)
+      end
+    end
+
+    context "when in the config file as a string" do
+      it "matches the config file" do
+        Quke::Configuration.file_location = data_path(".as_string.yml")
+        expect(subject.parallel).to eq(true)
+      end
+    end
+  end
+
   describe "#pause" do
     context "when NOT specified in the config file" do
       it "defaults to 0" do

--- a/spec/quke/cuke_runner_spec.rb
+++ b/spec/quke/cuke_runner_spec.rb
@@ -5,32 +5,23 @@ require "spec_helper"
 RSpec.describe Quke::CukeRunner do
   let(:default_args) do
     features_folder = __dir__.sub!("spec/quke", "lib/features")
-    ["spec", "-r", features_folder, "-r", "spec"]
+    ["features", "--type", "cucumber", "--serialize-stdout", "--combine-stderr", "--single", "--quiet", "--test-options", "--format pretty -r #{features_folder} -r features "]
   end
   describe "#initialize" do
     context "no additional Cucumber arguments passed" do
-      let(:subject) { Quke::CukeRunner.new("spec") }
+      let(:subject) { Quke::CukeRunner.new }
       it "returns just the default args used by Quke" do
         expect(subject.args).to eq(default_args)
       end
     end
     context "additional Cucumber arguments passed" do
       let(:args) { ["--tags", "test"] }
-      let(:subject) { Quke::CukeRunner.new("spec", args) }
+      let!(:subject) { Quke::CukeRunner.new(args) }
       it "returns the default args plus those passed in" do
-        expect(subject.args).to eq(default_args + args)
+        expected_args = default_args
+        expected_args[-1] = expected_args.last + args.join(" ")
+        expect(subject.args).to eq(expected_args)
       end
-    end
-  end
-
-  describe "#run" do
-    before(:example) do
-      Quke::Configuration.file_location = data_path(".no_file.yml")
-      Quke::Quke.config = Quke::Configuration.new
-    end
-    let(:subject) { Quke::CukeRunner.new("spec") }
-    it "does not raise an error when called" do
-      expect { subject.run }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
Because acceptance tests need to run against the actual service using the browser they can be much slower than unit tests.

To help this change adds support for running tests in parallel by implementing the [Parallel Tests gem](https://github.com/grosser/parallel_tests).

Parallel Tests is a bit like Quke in that it takes the arguments passed in and then uses them to call multiple instances of cucumber on multiple threads.

Because if this we are moving away from calling Cucumber through its CLI, and instead using the `ParallelTests::CLI` instead. The difference is if the config option `parallel:` is set
to false, we run ParallelTests in single mode which just starts one process mimicking what would     happen if we called cucumber directly. If set to true, we let ParallelTests do its thing.

Also because `lib/features/support/env.rb` is instantiated separately in each process, it does not have access to the global `Quke::Configuration` hence we now need to instantiate it within `env.rb`. Because of this change and the need to access it within `Quke::CukeRunner` we've also dropped setting the config in the exe file, and instead do it in the `Quke::CukeRunner.initialize`.

N.B. Because of the change to use ParallelTests for all executions, we now get an error if we run with `features_folder` pointing to somewhere that doesn't exist. We were not able to fix the unit test at this time so we're taking the test coverage hit and will come back to it later.