### PR TITLE
Add option to control display failures

### DIFF
--- a/.config.example.yml
+++ b/.config.example.yml
@@ -4,6 +4,67 @@
 # The default is features
 features_folder: 'cukes'
 
+# Normally Capybara expects to be testing an in-process Rack application, but
+# we're using it to talk to a remote host. Users of Quke can set what this
+# will be by simply setting `app_host`. You can then use it directly using
+# Capybara `visit('/Main_Page')` or `visit('/')` rather than having to repeat
+# the full url each time
+app_host: 'https://en.wikipedia.org/wiki'
+
+# Tells Quke which browser to use for testing. Choices are firefox, chrome,
+# browserstack and phantomjs, with the default being phantomjs
+driver: chrome
+
+# Let Quke know you want to run the browser in headless mode. Headless mode
+# means the browser still runs but you won't see it displayed. The benefit is
+# that your tests will take less time as it's less resource intensive.
+# This option only applies when the driver is set to 'chrome' or 'firefox'.
+# Phantomjs is a headless only browser, and option is meaningless for
+# browserstack
+headless: true
+
+# Add a pause (in seconds) between steps so you can visually track how the
+# browser is responding. Only useful if using a non-headless browser. The
+# default is 0
+pause: 1
+
+# Specify whether Quke should stop all tests once an error occurs. Useful in
+# Continuous Integration (CI) environments where a quick Yes/No is preferable to
+# a detailed response.
+stop_on_error: 1
+
+# By default Quke will display web pages where a failure has taken place.
+# A copy of the html is saved and Quke will display it in your default browser.
+# This can be useful to diagnose why something has failed, but there are times
+# you may not want Quke to do this.
+#
+# Please note, if the driver is phantomjs or the `headless` is true nothing will
+# be displayed even if this is set to true.
+display_failures: false
+
+# Capybara will attempt to find an element for a period of time, rather than
+# immediately failing because the element cannot be found. This defaults to 2
+# seconds. However if the site you are working with is slow or features
+# elements that take some time to load you can increase this default.
+max_wait_time: 5
+
+# Tell the driver Quke is using to send a different user-agent value to the site
+# under test. Useful if you want the underlying driver to spoof what kind of
+# browser the request is coming from. For example you may want to pretend to be
+# a mobile browser so you can check what you get back versus the desktop
+# version. Or you want to pretend to be another kind of browser, because the one
+# you have is not supported by the site.
+user_agent: "Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)"
+
+# Currently only supported when using the phantomjs driver (ignored by the
+# others). In phantomjs if a site has a javascript error we can configure it
+# to throw an error which will cause the test to fail. Quke by default sets this
+# to true, however you can override it by setting this flag to false.
+# For example you may be dealing with a legacy site and JavaScript errors
+# are out of your scope. You still want to test other aspects of the site
+# but not let these errors prevent you from using phantomjs.
+javascript_errors: false
+
 # Tell Quke you want to run tests in parallel. This will make use of the
 # available cores on your machine to run the tests in parallel, reducing the
 # time it takes them to run.
@@ -37,58 +98,6 @@ parrellel:
   # to complete the tests. Note, with each increase the reduction in time will
   # decrease to a point where it might become detrimental
   processes: 4
-
-# Normally Capybara expects to be testing an in-process Rack application, but
-# we're using it to talk to a remote host. Users of Quke can set what this
-# will be by simply setting `app_host`. You can then use it directly using
-# Capybara `visit('/Main_Page')` or `visit('/')` rather than having to repeat
-# the full url each time
-app_host: 'https://en.wikipedia.org/wiki'
-
-# Tells Quke which browser to use for testing. Choices are firefox, chrome,
-# browserstack and phantomjs, with the default being phantomjs
-driver: chrome
-
-# Let Quke know you want to run the browser in headless mode. Headless mode
-# means the browser still runs but you won't see it displayed. The benefit is
-# that your tests will take less time as it's less resource intensive.
-# This option only applies when the driver is set to 'chrome' or 'firefox'.
-# Phantomjs is a headless only browser, and option is meaningless for
-# browserstack
-headless: true
-
-# Add a pause (in seconds) between steps so you can visually track how the
-# browser is responding. Only useful if using a non-headless browser. The
-# default is 0
-pause: 1
-
-# Specify whether Quke should stop all tests once an error occurs. Useful in
-# Continuous Integration (CI) environments where a quick Yes/No is preferable to
-# a detailed response.
-stop_on_error: 1
-
-# Capybara will attempt to find an element for a period of time, rather than
-# immediately failing because the element cannot be found. This defaults to 2
-# seconds. However if the site you are working with is slow or features
-# elements that take some time to load you can increase this default.
-max_wait_time: 5
-
-# Tell the driver Quke is using to send a different user-agent value to the site
-# under test. Useful if you want the underlying driver to spoof what kind of
-# browser the request is coming from. For example you may want to pretend to be
-# a mobile browser so you can check what you get back versus the desktop
-# version. Or you want to pretend to be another kind of browser, because the one
-# you have is not supported by the site.
-user_agent: "Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)"
-
-# Currently only supported when using the phantomjs driver (ignored by the
-# others). In phantomjs if a site has a javascript error we can configure it
-# to throw an error which will cause the test to fail. Quke by default sets this
-# to true, however you can override it by setting this flag to false.
-# For example you may be dealing with a legacy site and JavaScript errors
-# are out of your scope. You still want to test other aspects of the site
-# but not let these errors prevent you from using phantomjs.
-javascript_errors: false
 
 # Anything you place under the 'custom' node in the `.config.yml` file will be
 # available within your steps and page objects by calling

--- a/lib/features/support/after_hook.rb
+++ b/lib/features/support/after_hook.rb
@@ -23,13 +23,13 @@ After("not @nonweb") do |scenario|
     if Quke::Quke.config.stop_on_error || $fail_count >= 5
       Cucumber.wants_to_quit = true
     else
-      # If we're not using poltergiest or running in headless mode and the
-      # scenario has failed, we want to save a copy of the page and open it
-      # automatically using Launchy. We wrap this in a begin/rescue in case of
-      # any issues in which case it defaults to outputting the source to STDOUT.
+      # Depending on our config, driver and whether we are running headless we
+      # may want to save a copy of the page and open it automatically using
+      # Launchy. We wrap this in a begin/rescue in case of any issues in which
+      # case it defaults to outputting the source to STDOUT.
       begin
         # rubocop:disable Lint/Debugger
-        save_and_open_page unless Quke::Quke.config.headless
+        save_and_open_page if Quke::Quke.config.display_failures?
         # rubocop:enable Lint/Debugger
       rescue StandardError
         # handle e

--- a/lib/quke/configuration.rb
+++ b/lib/quke/configuration.rb
@@ -120,6 +120,26 @@ module Quke #:nodoc:
       # rubocop:enable Security/YAMLLoad
     end
 
+    # Returns the value set for +display_failures+.
+    #
+    # Tells Quke not to display the html for the last page when a failure
+    # happens. Quke uses Capybara to save a copy of the page as html and uses
+    # launchy to display it in the default browser.
+    def display_failures
+      @data["display_failures"]
+    end
+
+    # Returns whether failures should be displayed.
+    #
+    # If the browser is headless then we never display failures, even if the
+    # setting has been set to true. Else whether we display a failure is based
+    # on the value set for display_failures.
+    def display_failures?
+      return false if headless
+
+      display_failures
+    end
+
     # Return the value for +max_wait_time+
     #
     # +max_wait_time+ is the time Capybara will spend waiting for an element
@@ -219,6 +239,7 @@ module Quke #:nodoc:
         # Else the condition fails and we get 'false', which when flipped gives
         # us 'true', which is what we want the default value to be
         # rubocop:disable Style/InverseMethods
+        "display_failures" => !(data["display_failures"].to_s.downcase.strip == "false"),
         "javascript_errors" => !(data["javascript_errors"].to_s.downcase.strip == "false"),
         # rubocop:enable Style/InverseMethods
         "custom" => (data["custom"] || nil)

--- a/spec/data/.as_string.yml
+++ b/spec/data/.as_string.yml
@@ -7,6 +7,7 @@ max_wait_time: '3'
 headless: 'true'
 parallel: 'true'
 javascript_errors: 'false'
+display_failures: 'false'
 
 proxy:
   port: '8080'

--- a/spec/data/.display_failures.yml
+++ b/spec/data/.display_failures.yml
@@ -1,0 +1,1 @@
+display_failures: false

--- a/spec/data/.should_display_failures.yml
+++ b/spec/data/.should_display_failures.yml
@@ -1,0 +1,2 @@
+display_failures: true
+headless: true

--- a/spec/quke/configuration_spec.rb
+++ b/spec/quke/configuration_spec.rb
@@ -120,6 +120,59 @@ RSpec.describe Quke::Configuration do
     end
   end
 
+  describe "#display_failures" do
+    context "when NOT specified in the config file" do
+      it "defaults to true" do
+        Quke::Configuration.file_location = data_path(".no_file.yml")
+        expect(subject.display_failures).to eq(true)
+      end
+    end
+
+    context "when specified in the config file" do
+      it "matches the config file" do
+        Quke::Configuration.file_location = data_path(".display_failures.yml")
+        expect(subject.display_failures).to eq(false)
+      end
+    end
+
+    context "when in the config file as a string" do
+      it "matches the config file" do
+        Quke::Configuration.file_location = data_path(".as_string.yml")
+        expect(subject.display_failures).to eq(false)
+      end
+    end
+  end
+
+  describe "#display_failures?" do
+    context "when `headless` is false and `display_failures` is false" do
+      it "returns false" do
+        Quke::Configuration.file_location = data_path(".display_failures.yml")
+        expect(subject.display_failures?).to eq(false)
+      end
+    end
+
+    context "when `headless` is true and `display_failures` is false" do
+      it "returns false" do
+        Quke::Configuration.file_location = data_path(".as_string.yml")
+        expect(subject.display_failures?).to eq(false)
+      end
+    end
+
+    context "when `headless` is false and `display_failures` is true" do
+      it "returns false" do
+        Quke::Configuration.file_location = data_path(".no_file.yml")
+        expect(subject.display_failures?).to eq(true)
+      end
+    end
+
+    context "when `headless` is true and `display_failures` is true" do
+      it "returns false" do
+        Quke::Configuration.file_location = data_path(".should_display_failures.yml")
+        expect(subject.display_failures?).to eq(false)
+      end
+    end
+  end
+
   describe "#max_wait_time" do
     context "when NOT specified in the config file" do
       it "defaults to whatever the Capybara default is" do


### PR DESCRIPTION
By default Quke will display web pages where a failure has taken place. A copy of the html is saved and Quke will display it in your default browser. This can be useful to diagnose why something has failed, but there are times you may not want Quke to do this.

This change adds an option to the config that allows users of Quke to control whether failures get displayed or not.