### PR TITLE
Fix error with parallel args for processes

### DIFF
--- a/lib/quke/parallel_configuration.rb
+++ b/lib/quke/parallel_configuration.rb
@@ -17,7 +17,7 @@ module Quke #:nodoc:
       args = standard_args(features_folder)
       args += ["--single", "--quiet"] unless @enabled
       args += ["--group-by", @group_by] unless @group_by == "default"
-      args += ["-n", @processes.to_s] if @processes.positive?
+      args += ["-n", @processes.to_s] if @enabled && @processes.positive?
       args + test_options_args(features_folder, additional_args)
     end
 

--- a/spec/quke/parallel_configuration_spec.rb
+++ b/spec/quke/parallel_configuration_spec.rb
@@ -79,11 +79,21 @@ RSpec.describe Quke::ParallelConfiguration do
     end
 
     context "when the instance has been instantiated with processes set" do
-      subject { Quke::ParallelConfiguration.new("processes" => "4") }
+      subject { Quke::ParallelConfiguration.new("enable" => "true", "processes" => "4") }
 
       it "returns an array with the args '-n' and '4'" do
         args = subject.command_args(feature_folder)
         expect(args).to include("-n", "4")
+      end
+
+    end
+
+    context "when the instance has been instantiated with processes set but parallel disabled" do
+      subject { Quke::ParallelConfiguration.new("processes" => "4") }
+
+      it "returns an array without the args '-n' and '4'" do
+        args = subject.command_args(feature_folder)
+        expect(args).not_to include("-n", "4")
       end
 
     end


### PR DESCRIPTION
Spotted an issue with the parallel args when the number of processes have been set in the config, but paraellel itself is disabled.

Prior to this change it would add all the args `["--single", "--quiet", "-n", "4"] which essentially means ParallelTests ignores `--single`.