### PR TITLE
Correct stop_on_error example

### DIFF
--- a/.config.example.yml
+++ b/.config.example.yml
@@ -30,8 +30,13 @@ pause: 1
 
 # Specify whether Quke should stop all tests once an error occurs. Useful in
 # Continuous Integration (CI) environments where a quick Yes/No is preferable to
-# a detailed response.
-stop_on_error: 1
+# a detailed response. By default Quke sets this to false if not set in the
+# config.
+#
+# If you are running in parallel mode this gets applied to each process spawned.
+# So if 4 processes are spawned and one of them errors, only the one that errors
+# will be stopped.
+stop_on_error: true
 
 # By default Quke will display web pages where a failure has taken place.
 # A copy of the html is saved and Quke will display it in your default browser.


### PR DESCRIPTION
The example for `stop_on_error` in the config used a value of 1, rather than true or false (which is how the option actually works).

This corrects the example and updates the notes for it based on latest changes.