### PR TITLE
Move proxy configuration to its own class

### DIFF
--- a/lib/quke.rb
+++ b/lib/quke.rb
@@ -11,6 +11,7 @@ require "quke/cuke_runner"
 require "quke/driver_registration"
 require "quke/driver_configuration"
 require "quke/parallel_configuration"
+require "quke/proxy_configuration"
 
 module Quke #:nodoc:
 

--- a/lib/quke/browserstack_configuration.rb
+++ b/lib/quke/browserstack_configuration.rb
@@ -136,10 +136,10 @@ module Quke #:nodoc:
         # Rather than
         "logfile" => File.join(Dir.pwd, "/tmp/bowerstack_local_log.txt")
       }
-      return unless configuration.use_proxy?
+      return unless configuration.proxy.use_proxy?
 
-      @local_testing_args["proxyHost"] = configuration.proxy["host"]
-      @local_testing_args["proxyPort"] = configuration.proxy["port"].to_s
+      @local_testing_args["proxyHost"] = configuration.proxy.host
+      @local_testing_args["proxyPort"] = configuration.proxy.port.to_s
     end
 
   end

--- a/lib/quke/driver_configuration.rb
+++ b/lib/quke/driver_configuration.rb
@@ -112,7 +112,7 @@ module Quke #:nodoc:
         "--ignore-ssl-errors=yes"
       ]
 
-      options.push("--proxy=#{config.proxy['host']}:#{config.proxy['port']}") if config.use_proxy?
+      options.push("--proxy=#{config.proxy.host}:#{config.proxy.port}") if config.proxy.use_proxy?
 
       options
     end
@@ -147,15 +147,13 @@ module Quke #:nodoc:
     #     )
     #
     def chrome
-      host = config.proxy["host"]
-      port = config.proxy["port"]
-      no_proxy = config.proxy["no_proxy"].tr(",", ";")
+      no_proxy = config.proxy.no_proxy.tr(",", ";")
 
       options = Selenium::WebDriver::Chrome::Options.new
       options.headless! if config.headless
 
-      options.add_argument("--proxy-server=#{host}:#{port}") if config.use_proxy?
-      options.add_argument("--proxy-bypass-list=#{no_proxy}") unless config.proxy["no_proxy"].empty?
+      options.add_argument("--proxy-server=#{config.proxy.host}:#{config.proxy.port}") if config.proxy.use_proxy?
+      options.add_argument("--proxy-bypass-list=#{no_proxy}") unless config.proxy.no_proxy.empty?
 
       options.add_argument("--user-agent=#{config.user_agent}") unless config.user_agent.empty?
 
@@ -250,11 +248,11 @@ module Quke #:nodoc:
       profile["general.useragent.override"] = config.user_agent unless config.user_agent.empty?
 
       settings = {}
-      settings[:http] = "#{config.proxy['host']}:#{config.proxy['port']}" if config.use_proxy?
-      settings[:ssl] = settings[:http] if config.use_proxy?
-      settings[:no_proxy] = config.proxy["no_proxy"] unless config.proxy["no_proxy"].empty?
+      settings[:http] = "#{config.proxy.host}:#{config.proxy.port}" if config.proxy.use_proxy?
+      settings[:ssl] = settings[:http] if config.proxy.use_proxy?
+      settings[:no_proxy] = config.proxy.no_proxy unless config.proxy.no_proxy.empty?
 
-      profile.proxy = Selenium::WebDriver::Proxy.new(settings) if config.use_proxy?
+      profile.proxy = Selenium::WebDriver::Proxy.new(settings) if config.proxy.use_proxy?
 
       profile
     end

--- a/lib/quke/driver_configuration.rb
+++ b/lib/quke/driver_configuration.rb
@@ -247,12 +247,7 @@ module Quke #:nodoc:
       profile = Selenium::WebDriver::Firefox::Profile.new
       profile["general.useragent.override"] = config.user_agent unless config.user_agent.empty?
 
-      settings = {}
-      settings[:http] = "#{config.proxy.host}:#{config.proxy.port}" if config.proxy.use_proxy?
-      settings[:ssl] = settings[:http] if config.proxy.use_proxy?
-      settings[:no_proxy] = config.proxy.no_proxy unless config.proxy.no_proxy.empty?
-
-      profile.proxy = Selenium::WebDriver::Proxy.new(settings) if config.proxy.use_proxy?
+      profile.proxy = Selenium::WebDriver::Proxy.new(config.proxy.firefox_settings) if config.proxy.use_proxy?
 
       profile
     end

--- a/lib/quke/parallel_configuration.rb
+++ b/lib/quke/parallel_configuration.rb
@@ -5,7 +5,13 @@ module Quke #:nodoc:
   # Manages all parallel configuration for Quke.
   class ParallelConfiguration
 
-    attr_reader :enabled, :group_by, :processes
+    # Whether use of parallel tests has been enabled
+    attr_reader :enabled
+    # How to group the tests. Default is features
+    attr_reader :group_by
+    # How many processes to start. Default is 0 which means we will leave
+    # ParallelTests to determine the number.
+    attr_reader :processes
 
     def initialize(data = {})
       @enabled = (data["enable"].to_s.downcase.strip == "true")
@@ -13,6 +19,12 @@ module Quke #:nodoc:
       @processes = (data["processes"] || "0").to_s.downcase.strip.to_i
     end
 
+    # Returns an array of arguments, correctly ordered for passing to
+    # +ParallelTests::CLI.new.run()+.
+    #
+    # The arguments are based on the values set for the parallel configuration
+    # plus those passed in. It then orders them in an order that makes sense to
+    # parallel tests.
     def command_args(features_folder, additional_args = [])
       args = standard_args(features_folder)
       args += ["--single", "--quiet"] unless @enabled

--- a/lib/quke/proxy_configuration.rb
+++ b/lib/quke/proxy_configuration.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Quke #:nodoc:
+
+  # Manages all parallel configuration for Quke.
+  class ProxyConfiguration
+
+    attr_reader :host, :port, :no_proxy
+
+    def initialize(data = {})
+      @host = (data["host"] || "").downcase.strip
+      @port = (data["port"] || "0").to_s.downcase.strip.to_i
+      @no_proxy = (data["no_proxy"] || "").downcase.strip
+    end
+
+    # Return true if the +host+ value has been set in the +.config.yml+
+    # file, else false.
+    #
+    # It is mainly used when determining whether to apply proxy server settings
+    # to the different drivers when registering them with Capybara.
+    def use_proxy?
+      @host != ""
+    end
+
+  end
+
+end

--- a/lib/quke/proxy_configuration.rb
+++ b/lib/quke/proxy_configuration.rb
@@ -5,7 +5,16 @@ module Quke #:nodoc:
   # Manages all parallel configuration for Quke.
   class ProxyConfiguration
 
-    attr_reader :host, :port, :no_proxy
+    # The host address for the proxy server
+    attr_reader :host
+
+    # The port number for the proxy server
+    attr_reader :port
+
+    # In some cases you may also need to tell the driver not to use the proxy for local
+    # or specific connections. This returns a comma separated list of addresses of
+    # those addresses if set.
+    attr_reader :no_proxy
 
     def initialize(data = {})
       @host = (data["host"] || "").downcase.strip
@@ -20,6 +29,20 @@ module Quke #:nodoc:
     # to the different drivers when registering them with Capybara.
     def use_proxy?
       @host != ""
+    end
+
+    # Returns a hash of settings specific to initialising a
+    # +Selenium::WebDriver::Proxy+ instance, which will be created as part of
+    # registering the Selenium firefox driver
+    def firefox_settings
+      settings = {}
+      return settings unless use_proxy?
+
+      settings[:http] = "#{host}:#{port}"
+      settings[:ssl] = settings[:http]
+      settings[:no_proxy] = no_proxy unless no_proxy.empty?
+
+      settings
     end
 
   end

--- a/spec/data/.as_string.yml
+++ b/spec/data/.as_string.yml
@@ -12,6 +12,9 @@ display_failures: 'false'
 proxy:
   port: '8080'
 
+parallel:
+  processes: '4'
+
 browserstack:
   capabilities:
     browserstack.local: 'true'

--- a/spec/quke/configuration_spec.rb
+++ b/spec/quke/configuration_spec.rb
@@ -235,53 +235,6 @@ RSpec.describe Quke::Configuration do
     end
   end
 
-  describe "#proxy" do
-    context "when NOT specified in the config file" do
-      it "defaults to blank values" do
-        Quke::Configuration.file_location = data_path(".no_file.yml")
-        expect(subject.proxy).to eq("host" => "", "port" => 0, "no_proxy" => "")
-      end
-    end
-
-    context "when specified in the config file" do
-      it "matches the config file" do
-        Quke::Configuration.file_location = data_path(".proxy.yml")
-        expect(subject.proxy).to eq(
-          "host" => "10.10.2.70",
-          "port" => 8080,
-          "no_proxy" => "127.0.0.1,192.168.0.1"
-        )
-      end
-    end
-
-    context "when port is specified in the config file as a string" do
-      it "matches the config file" do
-        Quke::Configuration.file_location = data_path(".as_string.yml")
-        expect(subject.proxy).to eq(
-          "host" => "",
-          "port" => 8080,
-          "no_proxy" => ""
-        )
-      end
-    end
-  end
-
-  describe "#use_proxy?" do
-    context "when proxy host details are NOT specified in the config file" do
-      it "returns false" do
-        Quke::Configuration.file_location = data_path(".no_file.yml")
-        expect(subject.use_proxy?).to eq(false)
-      end
-    end
-
-    context "when proxy host details are specified in the config file" do
-      it "returns true" do
-        Quke::Configuration.file_location = data_path(".proxy_basic.yml")
-        expect(subject.use_proxy?).to eq(true)
-      end
-    end
-  end
-
   describe "#custom" do
     context "when NOT specified in the config file" do
       it "defaults to nothing" do

--- a/spec/quke/driver_configuration_spec.rb
+++ b/spec/quke/driver_configuration_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Quke::DriverConfiguration do
             "--load-images=no",
             "--disk-cache=false",
             "--ignore-ssl-errors=yes",
-            "--proxy=#{config.proxy['host']}:#{config.proxy['port']}"
+            "--proxy=#{config.proxy.host}:#{config.proxy.port}"
           ],
           inspector: true
         )
@@ -88,7 +88,7 @@ RSpec.describe Quke::DriverConfiguration do
             "--load-images=no",
             "--disk-cache=false",
             "--ignore-ssl-errors=yes",
-            "--proxy=#{config.proxy['host']}:#{config.proxy['port']}"
+            "--proxy=#{config.proxy.host}:#{config.proxy.port}"
           ]
         )
       end
@@ -126,7 +126,7 @@ RSpec.describe Quke::DriverConfiguration do
         config = Quke::Configuration.new
         expect(Quke::DriverConfiguration.new(config).chrome.args).to eq(
           Set[
-            "--proxy-server=#{config.proxy['host']}:#{config.proxy['port']}"
+            "--proxy-server=#{config.proxy.host}:#{config.proxy.port}"
           ]
         )
       end
@@ -138,7 +138,7 @@ RSpec.describe Quke::DriverConfiguration do
         config = Quke::Configuration.new
         expect(Quke::DriverConfiguration.new(config).chrome.args).to eq(
           Set[
-            "--proxy-server=#{config.proxy['host']}:#{config.proxy['port']}",
+            "--proxy-server=#{config.proxy.host}:#{config.proxy.port}",
             "--proxy-bypass-list=127.0.0.1;192.168.0.1"
           ]
         )

--- a/spec/quke/parallel_configuration_spec.rb
+++ b/spec/quke/parallel_configuration_spec.rb
@@ -31,6 +31,18 @@ RSpec.describe Quke::ParallelConfiguration do
       end
 
     end
+
+    context "when `.config.yml` contains a parallel section where processes is entered as a string" do
+      subject do
+        Quke::Configuration.file_location = data_path(".as_string.yml")
+        Quke::Configuration.new.parallel
+      end
+
+      it "returns an instance processes set as a number" do
+        expect(subject.processes).to eq(4)
+      end
+
+    end
   end
 
   describe "#command_args" do

--- a/spec/quke/proxy_configuration_spec.rb
+++ b/spec/quke/proxy_configuration_spec.rb
@@ -62,4 +62,40 @@ RSpec.describe Quke::ProxyConfiguration do
       end
     end
   end
+
+  describe "#firefox_settings" do
+    context "when the instance has been instantiated with no data" do
+      subject { Quke::ProxyConfiguration.new }
+
+      it "returns an empty hash" do
+        expect(subject.firefox_settings).to eq({})
+      end
+    end
+
+    context "when the instance has been instantiated with everything but 'host'" do
+      subject { Quke::ProxyConfiguration.new("port" => "8080", "no_proxy" => "127.0.0.1") }
+
+      it "returns an empty hash" do
+        expect(subject.firefox_settings).to eq({})
+      end
+    end
+
+    context "when the instance has been instantiated with data" do
+      subject do
+        Quke::ProxyConfiguration.new(
+          "host" => "10.10.2.70",
+          "port" => "8080",
+          "no_proxy" => "127.0.0.1"
+        )
+      end
+
+      it "returns a correctly populated hash" do
+        expect(subject.firefox_settings).to eq(
+          http: "10.10.2.70:8080",
+          ssl: "10.10.2.70:8080",
+          no_proxy: "127.0.0.1"
+        )
+      end
+    end
+  end
 end

--- a/spec/quke/proxy_configuration_spec.rb
+++ b/spec/quke/proxy_configuration_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Quke::ProxyConfiguration do
+  describe "instantiating" do
+    context "when `.config.yml` is blank or contains no parallel section" do
+      subject do
+        Quke::Configuration.file_location = data_path(".no_file.yml")
+        Quke::Configuration.new.proxy
+      end
+
+      it "returns an instance defaulted to blank values" do
+        expect(subject.host).to eq("")
+        expect(subject.port).to eq(0)
+        expect(subject.no_proxy).to eq("")
+      end
+
+    end
+
+    context "when `.config.yml` contains a proxy section" do
+      subject do
+        Quke::Configuration.file_location = data_path(".proxy.yml")
+        Quke::Configuration.new.proxy
+      end
+
+      it "returns an instance with properties that match the input" do
+        expect(subject.host).to eq("10.10.2.70")
+        expect(subject.port).to eq(8080)
+        expect(subject.no_proxy).to eq("127.0.0.1,192.168.0.1")
+      end
+
+    end
+
+    context "when `.config.yml` contains a proxy section where port is entered as a string" do
+      subject do
+        Quke::Configuration.file_location = data_path(".as_string.yml")
+        Quke::Configuration.new.proxy
+      end
+
+      it "returns an instance with port set as a number" do
+        expect(subject.port).to eq(8080)
+      end
+
+    end
+  end
+
+  describe "#use_proxy?" do
+    context "when the instance has been instantiated with no data" do
+      subject { Quke::ProxyConfiguration.new }
+
+      it "returns false" do
+        expect(subject.use_proxy?).to eq(false)
+      end
+    end
+
+    context "when the instance has been instantiated with 'host' set" do
+      subject { Quke::ProxyConfiguration.new("host" => "10.10.2.70") }
+
+      it "returns true" do
+        expect(subject.use_proxy?).to eq(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change brings the proxy configuration inline with the other configuration blocks parallel and browserstack.