### PR TITLE
Add option to use cucumber progress formatter

### DIFF
--- a/.config.example.yml
+++ b/.config.example.yml
@@ -70,6 +70,15 @@ user_agent: "Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)"
 # but not let these errors prevent you from using phantomjs.
 javascript_errors: false
 
+# If set Quke will tell Cucumber to output to the console using its
+# 'progress' formatter (simply displays a . for each passing scenario and F for
+# each failing one), rather than the default 'pretty' which displays each
+# scenario in detail.
+# If you don't need to see the detail on each run, this might be easier to
+# follow than the detailed output you see using the default 'pretty' print
+# format.
+print_prgress: false
+
 # Tell Quke you want to run tests in parallel. This will make use of the
 # available cores on your machine to run the tests in parallel, reducing the
 # time it takes them to run.

--- a/lib/quke/configuration.rb
+++ b/lib/quke/configuration.rb
@@ -183,6 +183,15 @@ module Quke #:nodoc:
       @data["javascript_errors"]
     end
 
+    # Returns the value set for +print_progress+.
+    #
+    # If set Quke will tell Cucumber to output to the console using its
+    # 'progress' formatter, rather than the default 'pretty' which displays each
+    # scenario in detail.
+    def print_progress
+      @data["print_progress"]
+    end
+
     # Return the hash of +custom+ server settings
     #
     # This returns a hash of all the key/values in the custom section of your
@@ -223,7 +232,8 @@ module Quke #:nodoc:
       # folder holding our predefined env.rb file.
       env_folder = __dir__.sub!("lib/quke", "lib/features")
       fail_fast = "--fail-fast" if stop_on_error
-      "#{fail_fast} --format pretty -r #{env_folder} -r #{features_folder} #{additional_args.join(' ')}".strip
+      print_format = print_progress ? "progress" : "pretty"
+      "#{fail_fast} --format #{print_format} -r #{env_folder} -r #{features_folder} #{additional_args.join(' ')}".strip
     end
 
     private
@@ -237,6 +247,7 @@ module Quke #:nodoc:
         "app_host" => (data["app_host"] || "").downcase.strip,
         "driver" => (data["driver"] || "phantomjs").downcase.strip,
         "headless" => (data["headless"].to_s.downcase.strip == "true"),
+        "print_progress" => (data["print_progress"].to_s.downcase.strip == "true"),
         "pause" => (data["pause"] || "0").to_s.downcase.strip.to_i,
         "stop_on_error" => (data["stop_on_error"] || "false").to_s.downcase.strip,
         "max_wait_time" => (data["max_wait_time"] || Capybara.default_max_wait_time).to_s.downcase.strip.to_i,

--- a/lib/quke/version.rb
+++ b/lib/quke/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Quke #:nodoc:
-  VERSION = "0.9.1"
+  VERSION = "0.10.0"
 end

--- a/spec/data/.as_string.yml
+++ b/spec/data/.as_string.yml
@@ -8,6 +8,7 @@ headless: 'true'
 parallel: 'true'
 javascript_errors: 'false'
 display_failures: 'false'
+print_progress: 'true'
 
 proxy:
   port: '8080'

--- a/spec/data/.print_progress.yml
+++ b/spec/data/.print_progress.yml
@@ -1,0 +1,1 @@
+print_progress: true

--- a/spec/quke/configuration_spec.rb
+++ b/spec/quke/configuration_spec.rb
@@ -235,6 +235,29 @@ RSpec.describe Quke::Configuration do
     end
   end
 
+  describe "#print_progress" do
+    context "when NOT specified in the config file" do
+      it "defaults to false" do
+        Quke::Configuration.file_location = data_path(".no_file.yml")
+        expect(subject.print_progress).to eq(false)
+      end
+    end
+
+    context "when specified in the config file" do
+      it "matches the config file" do
+        Quke::Configuration.file_location = data_path(".print_progress.yml")
+        expect(subject.print_progress).to eq(true)
+      end
+    end
+
+    context "when in the config file as a string" do
+      it "matches the config file" do
+        Quke::Configuration.file_location = data_path(".as_string.yml")
+        expect(subject.print_progress).to eq(true)
+      end
+    end
+  end
+
   describe "#custom" do
     context "when NOT specified in the config file" do
       it "defaults to nothing" do
@@ -304,6 +327,13 @@ RSpec.describe Quke::Configuration do
       it "returns the default cucumber arg value including the '--fail-fast' option" do
         Quke::Configuration.file_location = data_path(".stop_on_error.yml")
         expect(subject.cucumber_arg([])).to eq("--fail-fast #{default_arg}")
+      end
+    end
+
+    context "when `print_progress` is true" do
+      it "returns the default cucumber arg value including the '--format progress' option" do
+        Quke::Configuration.file_location = data_path(".print_progress.yml")
+        expect(subject.cucumber_arg([])).to include("--format progress")
       end
     end
 


### PR DESCRIPTION
The default way Cucumber prints to STDOUT is using its 'pretty' format. This essentially outputs the full scenario detail and the result of each step for every scenario.

This is great to see the detail and ensure your scenarios when read back make sense, however when running tests repeatedly you soon just want to know whether anything passed.

Hence adding this option for those that like to conserve their terminal space 😀.