### PR TITLE
Display progress when running non-parallel

### DIFF
--- a/lib/quke/parallel_configuration.rb
+++ b/lib/quke/parallel_configuration.rb
@@ -32,6 +32,7 @@ module Quke #:nodoc:
     def command_args(additional_args = [])
       args = standard_args(@config.features_folder)
       args += ["--single", "--quiet"] unless @enabled
+      args += ["--serialize-stdout", "--combine-stderr"] if @enabled
       args += ["--group-by", @group_by] unless @group_by == "default"
       args += ["-n", @processes.to_s] if @enabled && @processes.positive?
       args + ["--test-options", @config.cucumber_arg(additional_args)]
@@ -40,12 +41,7 @@ module Quke #:nodoc:
     private
 
     def standard_args(features_folder)
-      [
-        features_folder,
-        "--type", "cucumber",
-        "--serialize-stdout",
-        "--combine-stderr"
-      ]
+      [features_folder, "--type", "cucumber"]
     end
 
   end

--- a/spec/quke/parallel_configuration_spec.rb
+++ b/spec/quke/parallel_configuration_spec.rb
@@ -58,8 +58,6 @@ RSpec.describe Quke::ParallelConfiguration do
             "features",
             "--type",
             "cucumber",
-            "--serialize-stdout",
-            "--combine-stderr",
             "--single",
             "--quiet",
             "--test-options",
@@ -79,6 +77,11 @@ RSpec.describe Quke::ParallelConfiguration do
       it "returns an array without the args '--single' and '--quiet'" do
         args = subject.command_args
         expect(args).not_to include(["--single", "--quiet"])
+      end
+
+      it "returns an array with the args '--serialize-stdout' and '--combine-stderr'" do
+        args = subject.command_args
+        expect(args).not_to include(["--serialize-stdout", "--combine-stderr"])
       end
 
     end


### PR DESCRIPTION
By including the arguments `--serialize-stdout` and `--combine-stderr` to all calls to **ParallelTests** we were telling it not to output anything until the process has completed.

We believe this is needed when running using parallel else the output becomes confused. However when you are running without parallel this is no longer an issue, and users would expect to see something.