### PR TITLE
Fix issue with always running parallel

### DIFF
--- a/lib/quke/parallel_configuration.rb
+++ b/lib/quke/parallel_configuration.rb
@@ -31,9 +31,7 @@ module Quke #:nodoc:
     # parallel tests.
     def command_args(additional_args = [])
       args = standard_args(@config.features_folder)
-      args += ["--single", "--quiet"] unless @enabled
-      args += ["--serialize-stdout", "--combine-stderr"] if @enabled
-      args += ["--group-by", @group_by] unless @group_by == "default"
+      args += parallel_or_single_args
       args += ["-n", @processes.to_s] if @enabled && @processes.positive?
       args + ["--test-options", @config.cucumber_arg(additional_args)]
     end
@@ -42,6 +40,14 @@ module Quke #:nodoc:
 
     def standard_args(features_folder)
       [features_folder, "--type", "cucumber"]
+    end
+
+    def parallel_or_single_args
+      return ["--single", "--quiet"] unless @enabled
+
+      args = ["--serialize-stdout", "--combine-stderr"]
+      args += ["--group-by", @group_by] unless @group_by == "default"
+      args
     end
 
   end

--- a/spec/data/.no_parallel.yml
+++ b/spec/data/.no_parallel.yml
@@ -1,0 +1,4 @@
+parallel:
+  enable: false
+  group_by: "scenarios"
+  processes: 4

--- a/spec/quke/parallel_configuration_spec.rb
+++ b/spec/quke/parallel_configuration_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Quke::ParallelConfiguration do
 
     end
 
-    context "when the instance has been instantiated with parallel enabled" do
+    context "when the instance has been instantiated with parallel disabled" do
       subject do
         Quke::Configuration.file_location = data_path(".parallel.yml")
         Quke::Configuration.new.parallel
@@ -82,6 +82,24 @@ RSpec.describe Quke::ParallelConfiguration do
       it "returns an array with the args '--serialize-stdout' and '--combine-stderr'" do
         args = subject.command_args
         expect(args).not_to include(["--serialize-stdout", "--combine-stderr"])
+      end
+
+    end
+
+    context "when the instance has been instantiated with parallel enabled" do
+      subject do
+        Quke::Configuration.file_location = data_path(".no_parallel.yml")
+        Quke::Configuration.new.parallel
+      end
+
+      it "returns an array with the args '--single' and '--quiet'" do
+        args = subject.command_args
+        expect(args).not_to include(["--single", "--quiet"])
+      end
+
+      it "returns an array without the args '--serialize-stdout', '--combine-stderr' and '--group-by'" do
+        args = subject.command_args
+        expect(args).not_to include(["--serialize-stdout", "--combine-stderr", "--group-by"])
       end
 
     end


### PR DESCRIPTION
Found when using Quke that even if parallel was disabled it would always run parallel anyway even if `--single` had been passed in to ParallelTests.

After some testing found it was because we would still set `--group-by`. It must be that if this is set ParallelTests defaults back to attempting to run in parallel and ignores the `--single` argument.

Hence this change which now only sets `--group-by` if parallel is enabled in the config.