### PR TITLE
Migrate from helpers to webdrivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,24 @@ If you are running using Chrome or Firefox after the 5th failure Quke will autom
 
 If you are using the Browserstack driver, Quke will automatically update the status of the session recorded in Browserstack for you. If all tests pass, it will be marked as 'passed', else it will be marked as 'failed' (it defaults to 'completed').
 
+## Browser drivers
+
+A very simple overview of how things work is that
+
+- [Cucumber](https://github.com/cucumber/cucumber-ruby) runs the tests
+- [Capbybara](https://github.com/teamcapybara/capybara) is used in the tests to simplify working with Selenium
+- [Selenium](https://github.com/SeleniumHQ/selenium/tree/master/rb) is used to tell the browsers what to do
+- each browser has a driver ([Chromedriver](https://chromedriver.chromium.org/), [Geckodriver](https://github.com/mozilla/geckodriver) etc) which can interpret Selenium commands into actual actions
+
+For Quke to work those browser drivers need to be installed. Quke manages this for you using a tool called [Webdrivers](https://github.com/titusfortner/webdrivers). There may be times you want to check the version of these drivers, or force an update to a specific version.
+
+If your project is using [Rake](https://github.com/ruby/rake) add the following to the `Rakefile` and you can then access a series of helper functions, for example `rake webdrivers:chromedriver:version`
+
+```ruby
+require "quke"
+load "quke/Rakefile"
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/features/support/env.rb
+++ b/lib/features/support/env.rb
@@ -78,8 +78,8 @@ at_exit do
       else
         puts reporter.failed($session_id)
       end
-    rescue StandardError => err
-      puts err
+    rescue StandardError => e
+      puts e
     end
   end
   # rubocop:enable Style/GlobalVars

--- a/lib/quke.rb
+++ b/lib/quke.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "selenium/webdriver"
-require "chromedriver-helper"
+require "webdrivers"
 
 require "quke/version"
 require "quke/browserstack_configuration"

--- a/lib/quke/Rakefile
+++ b/lib/quke/Rakefile
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Add support to quke to run the webdrivers rake tasks from host project
+# https://github.com/titusfortner/webdrivers#rake-tasks
+#
+# An acceptance test project that has quke as a dependency can then do the
+# following to access these rake tasks directly
+#
+#   # Add to project's `Rakefile`
+#   require "quke"
+#   load "quke/Rakefile"
+#
+require "webdrivers"
+load "webdrivers/Rakefile"

--- a/quke.gemspec
+++ b/quke.gemspec
@@ -64,21 +64,12 @@ Gem::Specification.new do |spec|
   # is they run slower and isn't best suited to a CI environment.
   spec.add_dependency "selenium-webdriver", "~> 3.14"
 
-  # Needed when wishing to use Chrome for selenium tests. We could have chosen
-  # to install the chromedriver separately (and it seems more recent tutorials
-  # do it in that way). However in an effort to make using this gem as simple
-  # as possible we have gone with using the chromedriver-helper. To quote
-  # from it "Easy installation and use of chromedriver, the Chromium project's
-  # selenium webdriver adapter."
-  spec.add_dependency "chromedriver-helper", "~> 2.1"
-
-  # Needed when wishing to use Firefox for selenium tests. We could have chosen
-  # to install the geckodriver separately. However in an effort to make using
-  # this gem as simple as possible we have gone with using the
-  # geckodriver-helper. To quote from it "Easy installation and use of
-  # geckodriver, that provides the HTTP API described by the WebDriver protocol
-  # to communicate with Gecko browsers, such as Firefox."
-  spec.add_dependency "geckodriver-helper", "~> 0.23"
+  # Needed when wishing to use Chrome or Firefox for selenium tests. You can opt
+  # to install each driver separately. However in an effort to make using this
+  # gem as simple as possible we have gone with using webdrivers. To quote
+  # from it "Run Selenium tests more easily with automatic installation and
+  # updates for all supported webdrivers."
+  spec.add_dependency "webdrivers", "~> 4.0"
 
   # Experience has shown that keeping tests dry helps make them more
   # maintainable over time. One practice that helps is the use of the


### PR DESCRIPTION
In March 2019 the maintainer of [chromedriver-helper](https://github.com/flavorjones/chromedriver-helper) announced his intention to [end support for the gem](https://github.com/flavorjones/chromedriver-helper/issues/83).

He recommended everyone switch to using [webdrivers](https://github.com/titusfortner/webdrivers) instead.

So as of March 30 2019 chromedriver-helper has not been supported and the project archived. This change covers migrating to webdrivers. As webdrivers also handles the geckodriver for firefox as well as chromedriver, we're also able to drop [geckodriver-helper](https://github.com/DevicoSolutions/geckodriver-helper) in this change.

Resolves #95