### PR TITLE
Stop throwing error on cucumber test fails

### DIFF
--- a/lib/quke/cuke_runner.rb
+++ b/lib/quke/cuke_runner.rb
@@ -46,12 +46,16 @@ module Quke #:nodoc:
 
     # Executes Cucumber passing in the arguments array, which was set when the
     # instance of CukeRunner was initialized.
+    # rubocop:disable Lint/HandleExceptions
     def run
       Cucumber::Cli::Main.new(@args).execute!
-    rescue SystemExit => e
+    rescue SystemExit
       # Cucumber calls @kernel.exit() killing your script unless you rescue
-      raise StandardError, "Cucumber exited in a failed state" unless e.success?
+      # If any tests fail cucumber will exit with an error code however this
+      # is expected and normal behaviour. We capture the exit to prevent it
+      # bubbling up to our app and closing it.
     end
+    # rubocop:enable Lint/HandleExceptions
 
   end
 


### PR DESCRIPTION
If any tests fail when cucumber runs it throws a `SystemExit` with a failed status.

For no doubt valid reasons (at the time!) we handled this and then raised a `StandardError`. The result was that anyone running Quke that had any failing tests would see output that made it look like something was broken.

We don't believe we need to be doing this, and would rather have a clean exit after running cucumber.