### PR TITLE
Cleanup remnants from parallel_tests removal

### DIFF
--- a/.config.example.yml
+++ b/.config.example.yml
@@ -29,10 +29,6 @@ pause: 1
 # Continuous Integration (CI) environments where a quick Yes/No is preferable to
 # a detailed response. By default Quke sets this to false if not set in the
 # config.
-#
-# If you are running in parallel mode this gets applied to each process spawned.
-# So if 4 processes are spawned and one of them errors, only the one that errors
-# will be stopped.
 stop_on_error: true
 
 # By default Quke will display web pages where a failure has taken place.

--- a/lib/quke/cuke_runner.rb
+++ b/lib/quke/cuke_runner.rb
@@ -29,19 +29,7 @@ module Quke #:nodoc:
     #       set this to be sure to handle tagged scenarios
     def initialize(passed_in_args = [])
       Quke.config = Configuration.new
-      @args = [
-        Quke.config.features_folder,
-        # Because cucumber is called in the context of the executing script it
-        # will take the next argument from that position, not from where the gem
-        # currently sits. This means to Cucumber 'lib/features' doesn't exist,
-        # which means our env.rb never gets loaded. Instead we first have to
-        # determine where this file is running from when called, then we simply
-        # replace the last part of that result (which we know will be lib/quke)
-        # with lib/features. We then pass this full path to Cucumber so it can
-        # correctly find the folder holding our predefined env.rb file.
-        "-r", __dir__.sub!("lib/quke", "lib/features"),
-        "-r", Quke.config.features_folder
-      ] + passed_in_args
+      @args = Quke.config.cucumber_args(passed_in_args)
     end
 
     # Executes Cucumber passing in the arguments array, which was set when the

--- a/lib/quke/proxy_configuration.rb
+++ b/lib/quke/proxy_configuration.rb
@@ -2,7 +2,7 @@
 
 module Quke #:nodoc:
 
-  # Manages all parallel configuration for Quke.
+  # Manages all proxy configuration for Quke.
   class ProxyConfiguration
 
     # The host address for the proxy server

--- a/spec/data/.as_string.yml
+++ b/spec/data/.as_string.yml
@@ -5,16 +5,12 @@ pause: '1'
 stop_on_error: 'true'
 max_wait_time: '3'
 headless: 'true'
-parallel: 'true'
 javascript_errors: 'false'
 display_failures: 'false'
 print_progress: 'true'
 
 proxy:
   port: '8080'
-
-parallel:
-  processes: '4'
 
 browserstack:
   capabilities:

--- a/spec/data/.simple.yml
+++ b/spec/data/.simple.yml
@@ -8,11 +8,6 @@ pause: 1
 stop_on_error: true
 max_wait_time: 3
 
-parallel:
-  enable: true
-  group_by: "scenarios"
-  processes: 4
-
 browserstack:
   username: jdoe
   auth_key: 123456789ABCDE

--- a/spec/quke/configuration_spec.rb
+++ b/spec/quke/configuration_spec.rb
@@ -289,35 +289,47 @@ RSpec.describe Quke::Configuration do
     end
   end
 
-  describe "#cucumber_arg" do
-    let(:default_arg) { "--format pretty -r #{File.join(Dir.pwd, 'lib', 'features')} -r features" }
+  describe "#cucumber_args" do
+    let(:feature_folder_args) { ["features", "-r", File.join(Dir.pwd, "lib", "features"), "-r", "features"] }
+    let(:format_pretty_args) { ["--format", "pretty"] }
+    let(:format_progress_args) { ["--format", "progress"] }
+    let(:fail_fast_args) { ["--fail-fast"] }
     let(:additional_args) { ["--tags", "@wip"] }
+    let(:additional_whitespace_args) { [" --tags ", " @wip "] }
 
     context "when there are no additional arguments" do
-      it "returns the default cucumber arg value" do
+      it "returns the default cucumber args value" do
         Quke::Configuration.file_location = data_path(".no-file.yml")
-        expect(subject.cucumber_arg([])).to eq(default_arg)
+        expect(subject.cucumber_args([])).to eq(format_pretty_args + feature_folder_args)
       end
     end
 
     context "when `stop_on_error` is true" do
-      it "returns the default cucumber arg value including the '--fail-fast' option" do
+      it "returns the default cucumber arg values including the '--fail-fast' option" do
         Quke::Configuration.file_location = data_path(".stop_on_error.yml")
-        expect(subject.cucumber_arg([])).to eq("--fail-fast #{default_arg}")
+
+        expect(subject.cucumber_args([])).to eq(format_pretty_args + fail_fast_args + feature_folder_args)
       end
     end
 
     context "when `print_progress` is true" do
-      it "returns the default cucumber arg value including the '--format progress' option" do
+      it "returns the default cucumber arg values including the '--format progress' option" do
         Quke::Configuration.file_location = data_path(".print_progress.yml")
-        expect(subject.cucumber_arg([])).to include("--format progress")
+        expect(subject.cucumber_args([])).to eq(format_progress_args + feature_folder_args)
       end
     end
 
     context "when there are additional arguments" do
-      it "returns the default cucumber arg value plus the arguments" do
+      it "returns the default cucumber arg values plus the arguments" do
         Quke::Configuration.file_location = data_path(".no-file.yml")
-        expect(subject.cucumber_arg(additional_args)).to eq("#{default_arg} #{additional_args.join(' ')}")
+        expect(subject.cucumber_args(additional_args)).to eq(format_pretty_args + feature_folder_args + additional_args)
+      end
+
+      context "and some arguments have whitespace around them" do
+        it "returns the default cucumber arg values plus the arguments without whitespace" do
+          Quke::Configuration.file_location = data_path(".no-file.yml")
+          expect(subject.cucumber_args(additional_whitespace_args)).to eq(format_pretty_args + feature_folder_args + additional_args)
+        end
       end
     end
   end

--- a/spec/quke/proxy_configuration_spec.rb
+++ b/spec/quke/proxy_configuration_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 RSpec.describe Quke::ProxyConfiguration do
   describe "instantiating" do
-    context "when `.config.yml` is blank or contains no parallel section" do
+    context "when `.config.yml` is blank" do
       subject do
         Quke::Configuration.file_location = data_path(".no_file.yml")
         Quke::Configuration.new.proxy


### PR DESCRIPTION
When we removed [parallel_tests](https://github.com/grosser/parallel_tests) in PR #98 we weren't as thorough as we should have been.

Also by simply pasting in the old way of setting up the args for cucumber, we skipped taking advantage of some args we had previously added support for (`--format` and `--fail-fast`).

This this change is essentially a cleanup of the mess we left after removing parallel_tests.