### PR TITLE
Resolve issues and update spec structure

### DIFF
--- a/lib/quke/cuke_runner.rb
+++ b/lib/quke/cuke_runner.rb
@@ -34,7 +34,7 @@ module Quke #:nodoc:
 
     # Executes Cucumber passing in the arguments array, which was set when the
     # instance of CukeRunner was initialized.
-    # rubocop:disable Lint/HandleExceptions
+    # rubocop:disable Lint/SuppressedException
     def run
       Cucumber::Cli::Main.new(@args).execute!
     rescue SystemExit
@@ -43,7 +43,7 @@ module Quke #:nodoc:
       # is expected and normal behaviour. We capture the exit to prevent it
       # bubbling up to our app and closing it.
     end
-    # rubocop:enable Lint/HandleExceptions
+    # rubocop:enable Lint/SuppressedException
 
   end
 

--- a/quke.gemspec
+++ b/quke.gemspec
@@ -84,9 +84,11 @@ Gem::Specification.new do |spec|
   # and provides an API for managing it.
   spec.add_dependency "browserstack-local"
 
-  spec.add_development_dependency "byebug"
   spec.add_development_dependency "defra_ruby_style"
   spec.add_development_dependency "github_changelog_generator"
+  # Adds step-by-step debugging and stack navigation capabilities to pry using
+  # byebug
+  spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rdoc"
   spec.add_development_dependency "rspec", "~> 3.8"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,39 +1,85 @@
 # frozen_string_literal: true
 
+require "bundler/setup"
+
 # Require and run our simplecov initializer as the very first thing we do.
 # This is as per its docs https://github.com/colszowka/simplecov#getting-started
 require "./spec/support/simplecov"
 
-# Support debugging in the tests
-require "byebug"
-
-# The following line is provided for convenience purposes. It has the downside
-# of increasing the boot-up time by auto-requiring all files in the support
-# directory. However in a small gem like this the increase should be neglible
-Dir[File.join(__dir__, "support", "**", "*.rb")].each { |f| require f }
-
-# Need to require our actual code files
-require "quke"
+# Requires supporting ruby files with custom matchers and macros, etc, in
+# spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
+# run as spec files by default. This means that files in spec/support that end
+# in _spec.rb will both be required and run as specs, causing the specs to be
+# run twice. It is recommended that you do not name files matching this glob to
+# end with _spec.rb. You can configure this pattern with the --pattern
+# option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
+#
+# We make an exception for simplecov because that will already have been
+# required and run at the very top of spec_helper.rb
+support_files = Dir["./spec/support/**/*.rb"].reject { |file| file == "./spec/support/simplecov.rb" }
+support_files.each { |f| require f }
 
 RSpec.configure do |config|
+  # rspec-expectations config goes here. You can use an alternate
+  # assertion/expectation library such as wrong or the stdlib/minitest
+  # assertions if you prefer.
+  config.expect_with :rspec do |expectations|
+    # This option will default to `true` in RSpec 4. It makes the `description`
+    # and `failure_message` of custom matchers include text for helper methods
+    # defined using `chain`, e.g.:
+    #     be_bigger_than(2).and_smaller_than(4).description
+    #     # => "be bigger than 2 and smaller than 4"
+    # ...rather than:
+    #     # => "be bigger than 2"
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  # rspec-mocks config goes here. You can use an alternate test double
+  # library (such as bogus or mocha) by changing the `mock_with` option here.
+  config.mock_with :rspec do |mocks|
+    # Prevents you from mocking or stubbing a method that does not exist on
+    # a real object. This is generally recommended, and will default to
+    # `true` in RSpec 4.
+    mocks.verify_partial_doubles = true
+  end
+
+  # This option will default to `:apply_to_host_groups` in RSpec 4 (and will
+  # have no way to turn it off -- the option exists only for backwards
+  # compatibility in RSpec 3). It causes shared context metadata to be
+  # inherited by the metadata hash of host groups and examples, rather than
+  # triggering implicit auto-inclusion in groups with matching metadata.
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  # This allows you to limit a spec run to individual examples or groups
+  # you care about by tagging them with `:focus` metadata. When nothing
+  # is tagged with `:focus`, all examples get run. RSpec also provides
+  # aliases for `it`, `describe`, and `context` that include `:focus`
+  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  config.filter_run_when_matching :focus
+
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.
   config.example_status_persistence_file_path = "spec/examples.txt"
 
-  # Disable RSpec exposing methods globally on `Module` and `main`
+  # Limits the available syntax to the non-monkey patched syntax that is
+  # recommended. For more details, see:
+  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
   config.disable_monkey_patching!
 
-  config.expect_with :rspec do |c|
-    c.syntax = :expect
-  end
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = :random
 
-  # Enable the ability to run only selected tests. This means rather than
-  # having to pass the specifics in at the command line we can denote which
-  # tests we want to run in the code.
-  # https://www.relishapp.com/rspec/rspec-core/docs/filtering/inclusion-filters
-  config.filter_run focus: true
-  config.run_all_when_everything_filtered = true
+  # Seed global randomization in this process using the `--seed` CLI option.
+  # Setting this allows you to use `--seed` to deterministically reproduce
+  # test failures related to randomization by passing the same `--seed` value
+  # as the one that triggered the failure.
+  Kernel.srand config.seed
 
   # Makes our helper methods available to all specs
   config.include Helpers

--- a/spec/support/pry.rb
+++ b/spec/support/pry.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Support debugging in the tests. Add `binding.pry` wherever you want execution
+# to stop and the debugger to kick in.
+# Details on the debugging commands can be found here
+# https://github.com/deivid-rodriguez/pry-byebug#commands
+require "pry-byebug"

--- a/spec/support/quke.rb
+++ b/spec/support/quke.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Need to require our actual code files.
+require "quke"


### PR DESCRIPTION
With the latest version of rubocop we were getting some errors with namespacing. It also highlgihted a deterministic sorting issue with how the `spec_helper.rb` was requiring support files. It was then we spotted that Quke's `spec_helper.rb` is really not that consistent with our other gems.

So this is a general fix and update change of minor things in the project.