### PR TITLE
Switch to SonarCloud from CodeClimate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,54 +1,24 @@
-# Needed as part of submitting test coverage statistics to CodeClimate as part
-# of the build
-# https://docs.codeclimate.com/v1.0/docs/travis-ci-test-coverage
-env:
-  global:
-    - CC_TEST_REPORTER_ID=1d329b5215a2aa892214c7705d36de6e99608a8649616c93f93464aa06776f4a
+dist: trusty
+
+addons:
+  sonarcloud:
+    organization: "defra"
 
 language: ruby
 rvm: 2.4.2
 cache: bundler
-# Travis CI clones repositories to a depth of 50 commits, which is only really
-# useful if you are performing git operations.
-# https://docs.travis-ci.com/user/customizing-the-build/#Git-Clone-Depth
+
+# Travis CI uses shallow clone to speed up build times, but a truncated SCM
+# history may cause issues when SonarCloud computes blame data. To avoid this,
+# you can access the full SCM history with `depth: false`
 git:
-  depth: 3
+  depth: false
 
 before_install:
   - export TZ=UTC
-  - gem install -v 1.17.2 bundler --no-rdoc --no-ri
+  - gem install -v 1.17.3 bundler --no-rdoc --no-ri
 
-# Using the ability to customise the Travis build to check for 'focus' labels
-# i.e. labels used when working on a spec but which we don't want appearing in
-# the final commit to master
-# Reworking of http://stackoverflow.com/a/30495279/6117745
-# If grep returns 0 (match found), test 0 -eq 1 will return 1.
-# If grep returns 1 (no match found), test 1 -eq 1 will return 0.
-# If grep returns 2 (error), test 2 -eq 1 will return 1.
-before_script:
-  - echo "Checking for use of 'focus' labels in specs" && grep -r --include="*_spec.rb" "focus&#58; true" spec/; test $? -eq 1
-  # Setup to support the CodeClimate test coverage submission
-  # As per CodeClimate's documentation, they suggest only running
-  # ./cc-test-reporter commands on travis-ci push builds only. Hence we wrap all
-  # the codeclimate test coverage related commands in a check that tests if we
-  # are in a pull request or not.
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter; fi
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then chmod +x ./cc-test-reporter; fi
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter before-build; fi
-  - bundle exec rubocop
-
-after_script:
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi
-
-deploy:
-  provider: rubygems
-  api_key:
-    secure: "mrNfo3ZlO4wtr7fp751jltjKZcWeFXLCxxVDHqJVnkdAKpDcbo99Phlq9+fh5Q/o8gIJ4jKQybvr/Zu5t8mrWYJKKLlsUi3UThJG5hOg64ynJKy3jqtU45uCGOc33oBhQAqHTfDI+DZxQTGs2TepoqdyxsSzki
-s9TRj+qyeE2HSO+yz5Qyjwql6o5k9xP82uBFaQI0WKqKdTtdNFv5LZ3EZaRWtyM/jGsunaNAYscDOl3cYN1sXlq+wfCTRvjMGmcppdbsaczQNQdIkXBPZEkydO7FdnSwUFuwm30BP0OBks5myB7oHWbbe0p/YRsUbjLF0dVfn
-AlSERSwhkpMOU1BpK4/vwPBoR8yzgfZG4UZAZQ6hCMtRj+2usKWcI4buryeD+iPDrkVX9FjziOC3OFSbMzo/ojYlkLjvvXuUcTAmWZr0V/VP1x7RAiHNA+Y7EqYRJFJcEE5Av7Yn+hgi8fUtLyiSDLOb4bGJ2fe9R3YeZQ1ge
-pvnarjriXfNZul3K1tP21/oVeXwCRuOjPMxwUmEsPCCjdIu/44U5CvGRbaqJXAqYJm71u+Y96RfkjytRnLmAc13nIBiFCUqUyoab4GIsy9AZ4TzE9ROGwLTC3y05gMVlYVJk4GTtVCjJwqNB2LWRXo/PseWaDdRZYmnNTr5wI
-kB5wbWRtEYUdIOb70c="
-  gem: quke
-  on:
-    tags: true
-    repo: DEFRA/quke
+script:
+  - bundle exec rubocop --format=json --out=rubocop-result.json
+  - bundle exec rspec
+  - sonar-scanner

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <img src="/quke.png" alt="Quke logo" />
 
 [![Build Status](https://travis-ci.org/DEFRA/quke.svg?branch=master)](https://travis-ci.org/DEFRA/quke)
-[![Maintainability](https://api.codeclimate.com/v1/badges/34f915556feb193d7d82/maintainability)](https://codeclimate.com/github/DEFRA/quke/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/34f915556feb193d7d82/test_coverage)](https://codeclimate.com/github/DEFRA/quke/test_coverage)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_quke&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=DEFRA_quke)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_quke&metric=coverage)](https://sonarcloud.io/dashboard?id=DEFRA_quke)
 [![security](https://hakiri.io/github/DEFRA/quke/master.svg)](https://hakiri.io/github/DEFRA/quke/master)
 [![Gem Version](https://badge.fury.io/rb/quke.svg)](https://badge.fury.io/rb/quke)
 [![Licence](https://img.shields.io/badge/Licence-OGLv3-blue.svg)](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,30 @@
+# Project key is required. You'll find it in the SonarCloud UI
+sonar.projectKey=DEFRA_quke
+sonar.organization=defra
+
+# This is the name and version displayed in the SonarCloud UI
+sonar.projectName=quke
+sonar.projectVersion=0.10.0
+
+# This will add the same links in the SonarCloud UI
+sonar.links.homepage=https://github.com/DEFRA/quke
+sonar.links.ci=https://travis-ci.com/DEFRA/quke
+sonar.links.scm=https://github.com/DEFRA/quke
+sonar.links.issue=https://github.com/DEFRA/ruby-services-team/issues
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on
+# Windows.
+# Because rails generates a number of files, and SonarCloud has no rails and
+# ruby intelligence we have found we have to specify what should be covered.
+# If we don't SonarCloud will do things like take the raw coverage data from
+# simplecov, compare that to all files ion the repo, and score 0 for all the
+# files we don't actually need to test. This severly deflates our scores and
+# means it is not consistent with our previous reporting tool CodeClimate.
+sonar.sources=./lib
+sonar.tests=./spec
+
+# Encoding of the source code. Default is default system encoding
+sonar.sourceEncoding=UTF-8
+
+sonar.ruby.coverage.reportPath=coverage/.resultset.json
+sonar.ruby.rubocop.reportPaths=rubocop-result.json


### PR DESCRIPTION
https://sonarcloud.io/organizations/defra/projects

We currently use Code Climate for our code quality checks and test coverage analysis. However a number of Defra projects have used an internal SonarQube instance, and some public ones have been using SonarCloud (the cloud SASS version of SonarQube).

It looks like we’re about to formally adopt SonarCloud and all projects will coalesce onto. So to keep on top of things and continue to be an example to others, we are working through our repos and switching them to SonarCloud.

** Notes

The figuring out of how to do this (because it wasn’t straight forward!) was done in

https://github.com/DEFRA/waste-exemptions-front-office/pull/317
https://github.com/DEFRA/waste-exemptions-front-office/pull/318