### PR TITLE
Use multiple rubocop formats in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ before_install:
   - gem install -v 1.17.3 bundler --no-rdoc --no-ri
 
 script:
-  - bundle exec rubocop --format=json --out=rubocop-result.json
+  - bundle exec rubocop --format progress --format json --out rubocop-result.json
   - bundle exec rspec
   - sonar-scanner

--- a/lib/quke/cuke_runner.rb
+++ b/lib/quke/cuke_runner.rb
@@ -34,7 +34,6 @@ module Quke #:nodoc:
 
     # Executes Cucumber passing in the arguments array, which was set when the
     # instance of CukeRunner was initialized.
-    # rubocop:disable Lint/SuppressedException
     def run
       Cucumber::Cli::Main.new(@args).execute!
     rescue SystemExit
@@ -43,7 +42,6 @@ module Quke #:nodoc:
       # is expected and normal behaviour. We capture the exit to prevent it
       # bubbling up to our app and closing it.
     end
-    # rubocop:enable Lint/SuppressedException
 
   end
 

--- a/quke.gemspec
+++ b/quke.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |spec|
   spec.summary       = "A gem to simplify creating acceptance tests using Cucumber"
   # My attempts to break this line up to meet the 120 char limit we have set
   # have proved fruitles so far!
-  # rubocop:disable Metrics/LineLength
+  # rubocop:disable Layout/LineLength
   spec.description   = "Quke tries to simplify the process of writing and running acceptance tests by setting up Cucumber for you. It handles the config to allow you to run your tests in Firefox or Chrome. It also has out of the box setup for using Browserstack automate. This leaves you to focus on just your features and steps."
-  # rubocop:enable Metrics/LineLength
+  # rubocop:enable Layout/LineLength
 
   spec.files = Dir["{bin,exe,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
   spec.bindir = "exe"


### PR DESCRIPTION
We initially used the default `progress` formatter when we first started building with Travis for our CI. When we then integrated with SonarCloud we switched the format to output a JSON file as that was what it needed. This meant if we got any rubocop issues it was no longer possible to see them in the build output. You would have to check SonarCloud.

Recently we have been getting a few projects fail because `bundle exec rubocop --format=json --out=rubocop-result.json` was returning exit code 1. As we couldn't immediately recreate the issue locally we assumed something might be broken with rubocop or our setup and chalked it up for further investigation. At the same time, we made sure our project [defra-ruby-style](https://github.com/DEFRA/defra-ruby-style) was using the latest version of rubocop and pushed a new release. This triggered a number of broken builds across our projects which forced us to investigate the [whole issue now](https://github.com/DEFRA/waste-carriers-engine/pull/806).

What came to light was

- rubocop does allow multiple formatters to be specified
- `bundle exec rubocop --format=json --out=rubocop-result.json` returning exit code 1 was valid. It was our local passing runs that were invalid

On this basis, we're going through all our repos and updating the Travis config to use an updated rubocop command

```bash
bundle exec rubocop --format progress --format json --out rubocop-result.json
```

This will mean we'll not only provide what SonarCloud needs, but we'll see immediately if the failure is because rubocop thinks there has been a violation. Hopefully, this will stop us getting confused in future!