### PR TITLE
Stop Quke from returning 0 exit status despite passing tests

### DIFF
--- a/lib/quke.rb
+++ b/lib/quke.rb
@@ -15,6 +15,12 @@ require "quke/proxy_configuration"
 
 module Quke #:nodoc:
 
+  class QukeError < StandardError
+    def message
+      "At least one Cucumber test failed"
+    end
+  end
+
   # The main Quke class. It is not intended to be instantiated and instead
   # just need to call its +execute+ method.
   class Quke
@@ -28,7 +34,11 @@ module Quke #:nodoc:
     # The entry point for Quke, it is the one call made by +exe/quke+.
     def self.execute(args = [])
       cuke = CukeRunner.new(args)
-      cuke.run
+      errors = cuke.run
+
+      if errors.any?
+        raise QukeError.new
+      end
     end
 
   end

--- a/lib/quke.rb
+++ b/lib/quke.rb
@@ -31,10 +31,9 @@ module Quke #:nodoc:
     def self.execute(args = [])
       cuke = CukeRunner.new(args)
       errors = cuke.run
+      return if errors.empty?
 
-      if errors.any?
-        raise QukeError.new("Number of failures or errors: #{errors.count}")
-      end
+      raise QukeError.new, "Number of failures or errors: #{errors.count}"
     end
 
   end

--- a/lib/quke.rb
+++ b/lib/quke.rb
@@ -15,11 +15,7 @@ require "quke/proxy_configuration"
 
 module Quke #:nodoc:
 
-  class QukeError < StandardError
-    def message
-      "At least one Cucumber test failed"
-    end
-  end
+  class QukeError < StandardError; end
 
   # The main Quke class. It is not intended to be instantiated and instead
   # just need to call its +execute+ method.
@@ -37,7 +33,7 @@ module Quke #:nodoc:
       errors = cuke.run
 
       if errors.any?
-        raise QukeError.new
+        raise QukeError.new("Number of failures or errors: #{errors.count}")
       end
     end
 

--- a/lib/quke/cuke_runner.rb
+++ b/lib/quke/cuke_runner.rb
@@ -35,12 +35,16 @@ module Quke #:nodoc:
     # Executes Cucumber passing in the arguments array, which was set when the
     # instance of CukeRunner was initialized.
     def run
+      errors = []
       Cucumber::Cli::Main.new(@args).execute!
-    rescue SystemExit
+
+      errors
+    rescue SystemExit => e
       # Cucumber calls @kernel.exit() killing your script unless you rescue
       # If any tests fail cucumber will exit with an error code however this
       # is expected and normal behaviour. We capture the exit to prevent it
       # bubbling up to our app and closing it.
+      errors << e
     end
 
   end

--- a/lib/quke/cuke_runner.rb
+++ b/lib/quke/cuke_runner.rb
@@ -38,7 +38,7 @@ module Quke #:nodoc:
       errors = []
 
       begin
-        status = Cucumber::Cli::Main.new(@args).execute!
+        Cucumber::Cli::Main.new(@args).execute!
       rescue SystemExit => e
         # Cucumber calls @kernel.exit() whenever a test fails, or when the test
         # suite has finished running. We prefer to run the full test suite every

--- a/lib/quke/cuke_runner.rb
+++ b/lib/quke/cuke_runner.rb
@@ -36,15 +36,18 @@ module Quke #:nodoc:
     # instance of CukeRunner was initialized.
     def run
       errors = []
-      Cucumber::Cli::Main.new(@args).execute!
+
+      begin
+        status = Cucumber::Cli::Main.new(@args).execute!
+      rescue SystemExit => e
+        # Cucumber calls @kernel.exit() whenever a test fails, or when the test
+        # suite has finished running. We prefer to run the full test suite every
+        # time, and then fail at the end. However if the SystemExit is a
+        # successful one, we don't want to log it as an error.
+        errors << e unless e.success?
+      end
 
       errors
-    rescue SystemExit => e
-      # Cucumber calls @kernel.exit() killing your script unless you rescue
-      # If any tests fail cucumber will exit with an error code however this
-      # is expected and normal behaviour. We capture the exit to prevent it
-      # bubbling up to our app and closing it.
-      errors << e
     end
 
   end

--- a/spec/quke/quke_spec.rb
+++ b/spec/quke/quke_spec.rb
@@ -60,11 +60,19 @@ RSpec.describe Quke do
       end
     end
 
-    context "when one of the tests errors" do
-      before { expect(Cucumber::Cli::Main).to receive(:new).and_raise(SystemExit) }
+    context "when one of the tests throws a SystemError with status 1" do
+      before { expect(Cucumber::Cli::Main).to receive(:new).and_raise(SystemExit, 1) }
 
       it "holds onto the errors and raises them at the end" do
-        expect { Quke::Quke.execute }.to raise_error(Quke::QukeError, "At least one Cucumber test failed")
+        expect { Quke::Quke.execute }.to raise_error(Quke::QukeError, "Number of failures or errors: 1")
+      end
+    end
+
+    context "when one of the tests throws a SystemError with status 0" do
+      before { expect(Cucumber::Cli::Main).to receive(:new).and_raise(SystemExit, 0) }
+
+      it "does not raise an error" do
+        expect { Quke::Quke.execute }.not_to raise_error
       end
     end
   end

--- a/spec/quke/quke_spec.rb
+++ b/spec/quke/quke_spec.rb
@@ -60,5 +60,12 @@ RSpec.describe Quke do
       end
     end
 
+    context "when one of the tests errors" do
+      before { expect(Cucumber::Cli::Main).to receive(:new).and_raise(SystemExit) }
+
+      it "holds onto the errors and raises them at the end" do
+        expect { Quke::Quke.execute }.to raise_error(Quke::QukeError, "At least one Cucumber test failed")
+      end
+    end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1373

The default behaviour here is for Cucumber to exit as soon as a single test fails. We prefer to run the full suite each time, so these errors were being rescued.

However, this meant that if a test did fail, the exit status of the job would still be 0, which isn't what we want for our CI.

This PR changes the behaviour of Quke to record if a test fails, allow the test suite to proceed, and then throw the error at the end instead.